### PR TITLE
FPGA Singleton, fix simulation code

### DIFF
--- a/Controller/CentOS/README.md
+++ b/Controller/CentOS/README.md
@@ -1,0 +1,4 @@
+## Dependencies
+
+MTM1M3
+MTM1M3TS

--- a/Controller/CentOS/makefile
+++ b/Controller/CentOS/makefile
@@ -6,9 +6,13 @@ endif
 
 # define to "" to produce verbose output
 
-C := gcc -O3 -Wall
-CPP := g++ -std=c++11 -pedantic -O3 -Wall
+C := gcc -O3 -Wall -g
+CPP := g++ -std=c++11 -pedantic -O3 -Wall -g
 LSSTROOT := /home/petr
+
+ifdef SIMULATOR
+  CPP += -DSIMULATOR
+endif
 
 BOOST_CPPFLAGS := -I/usr/include/boost169
 SAL_CPPFLAGS := -I$(LSSTROOT)/ts_opensplice/OpenSpliceDDS/V6.9/HDE/x86_64.linux/include -I$(LSSTROOT)/ts_opensplice/OpenSpliceDDS/V6.9/HDE/x86_64.linux/include/sys -I$(LSSTROOT)/ts_opensplice/OpenSpliceDDS/V6.9/HDE/x86_64.linux/include/dcps/C++/SACPP -I$(LSSTROOT)/ts_sal/test/MTM1M3/cpp/src -I$(LSSTROOT)/ts_sal/test/MTM1M3/cpp -I$(LSSTROOT)ts_sal/test/MTMount/cpp/src -I$(LSSTROOT)/ts_sal/include -I$(LSSTROOT)/ts_sal/test/MTMount/cpp -I$(LSSTROOT)/ts_sal/test -I$(LSSTROOT)/ts_sal/test/include
@@ -95,6 +99,6 @@ ts_M1M3Support: $(OBJS) $(USER_OBJS)
 
 # Other Targets
 clean:
-	$(foreach file,$(OBJS) $(C_DEPS) $(CPP_DEPS), echo '[RM ] ${file}'; $(RM) -r $(file);)
+	$(foreach file,$(OBJS) $(C_DEPS) $(CPP_DEPS) ts_M1M3Support, echo '[RM ] ${file}'; $(RM) -r $(file);)
 
 -include ../makefile.targets

--- a/Controller/CentOS/src/LSST/M1M3/SS/FPGA/subdir.mk
+++ b/Controller/CentOS/src/LSST/M1M3/SS/FPGA/subdir.mk
@@ -1,21 +1,20 @@
 # Add inputs and outputs from these tool invocations to the build variables 
-CPP_SRCS += \
-src/LSST/M1M3/SS/FPGA/ExpansionFPGA.cpp \
-src/LSST/M1M3/SS/FPGA/FPGA.cpp \
-src/LSST/M1M3/SS/FPGA/IFPGA.cpp \
-src/LSST/M1M3/SS/FPGA/IExpansionFPGA.cpp \
-src/LSST/M1M3/SS/FPGA/SimulatedExpansionFPGA.cpp \
-src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp 
+
+CPP_SRCS += src/LSST/M1M3/SS/FPGA/IFPGA.cpp src/LSST/M1M3/SS/FPGA/IExpansionFPGA.cpp
+
+ifdef SIMULATOR
+CPP_SRCS += src/LSST/M1M3/SS/FPGA/SimulatedExpansionFPGA.cpp src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp 
+else
+CPP_SRCS += src/LSST/M1M3/SS/FPGA/ExpansionFPGA.cpp src/LSST/M1M3/SS/FPGA/FPGA.cpp
+endif
 
 C_SRCS += src/LSST/M1M3/SS/FPGA/NiFpga.c 
 
 # Each subdirectory must supply rules for building sources it contributes
 src/LSST/M1M3/SS/FPGA/%.o: ../src/LSST/M1M3/SS/FPGA/%.cpp
-	@echo '[CPP] $<'
+	@echo '[CPP] $< $(CPP)'
 	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) -I"../src/LSST/M1M3/SS/DigitalInputOutput" -I"../src/LSST/M1M3/SS/FirmwareUpdate" -I"../src/LSST/M1M3/SS/Accelerometer" -I"../src/LSST/M1M3/SS/AutomaticOperationsController" -I"../src/LSST/M1M3/SS/BusLists" -I"../src/LSST/M1M3/SS/CommandFactory" -I"../src/LSST/M1M3/SS/Displacement" -I"../src/LSST/M1M3/SS/Inclinometer" -I"../src/LSST/M1M3/SS/ForceController" -I"../src/LSST/M1M3/SS/Commands" -I"../src/LSST/M1M3/SS/Context" -I"../src/LSST/M1M3/SS/Controller" -I"../src/LSST/M1M3/SS/Domain" -I"../src/LSST/M1M3/SS/FPGA" -I"../src/LSST/M1M3/SS/Gyro" -I"../src/LSST/M1M3/SS/ILC" -I"../src/LSST/M1M3/SS/Include" -I"../src/LSST/M1M3/SS/Logging" -I"../src/LSST/M1M3/SS/Modbus" -I"../src/LSST/M1M3/SS/Model" -I"../src/LSST/M1M3/SS/PID" -I"../src/LSST/M1M3/SS/PositionController" -I"../src/LSST/M1M3/SS/PowerController" -I"../src/LSST/M1M3/SS/Publisher" -I"../src/LSST/M1M3/SS/SafetyController" -I"../src/LSST/M1M3/SS/Settings" -I"../src/LSST/M1M3/SS/StateFactory" -I"../src/LSST/M1M3/SS/States" -I"../src/LSST/M1M3/SS/Subscriber" -I"../src/LSST/M1M3/SS/Threads" -I"../src/LSST/M1M3/SS/Utility" -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 
 src/LSST/M1M3/SS/FPGA/%.o: ../src/LSST/M1M3/SS/FPGA/%.c
 	@echo '[C  ] $<'
 	${co}$(C) -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
-
-

--- a/Controller/src/LSST/M1M3/SS/Accelerometer/Accelerometer.cpp
+++ b/Controller/src/LSST/M1M3/SS/Accelerometer/Accelerometer.cpp
@@ -7,6 +7,7 @@
 
 #include <Accelerometer.h>
 #include <AccelerometerSettings.h>
+#include <IFPGA.h>
 #include <SupportFPGAData.h>
 #include <M1M3SSPublisher.h>
 #include <Timestamp.h>
@@ -19,10 +20,9 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-Accelerometer::Accelerometer(AccelerometerSettings* accelerometerSettings, SupportFPGAData* fpgaData, M1M3SSPublisher* publisher) {
+Accelerometer::Accelerometer(AccelerometerSettings* accelerometerSettings, M1M3SSPublisher* publisher) {
 	Log.Debug("Accelerometer: Accelerometer()");
 	this->accelerometerSettings = accelerometerSettings;
-	this->fpgaData = fpgaData;
 	this->publisher = publisher;
 
 	this->accelerometerData = this->publisher->getAccelerometerData();
@@ -36,15 +36,16 @@ void Accelerometer::processData() {
 	// TODO: Handle no data available
 	// TODO: Handle acceleration limits, push to safety controller
 	Log.Trace("Accelerometer: processData()");
-	this->accelerometerData->timestamp = Timestamp::fromFPGA(this->fpgaData->AccelerometerSampleTimestamp);
-	this->accelerometerData->rawAccelerometer[0] = this->fpgaData->AccelerometerRaw1;
-	this->accelerometerData->rawAccelerometer[1] = this->fpgaData->AccelerometerRaw2;
-	this->accelerometerData->rawAccelerometer[2] = this->fpgaData->AccelerometerRaw3;
-	this->accelerometerData->rawAccelerometer[3] = this->fpgaData->AccelerometerRaw4;
-	this->accelerometerData->rawAccelerometer[4] = this->fpgaData->AccelerometerRaw5;
-	this->accelerometerData->rawAccelerometer[5] = this->fpgaData->AccelerometerRaw6;
-	this->accelerometerData->rawAccelerometer[6] = this->fpgaData->AccelerometerRaw7;
-	this->accelerometerData->rawAccelerometer[7] = this->fpgaData->AccelerometerRaw8;
+        SupportFPGAData *fpgaData = IFPGA::get().getSupportFPGAData();
+	this->accelerometerData->timestamp = Timestamp::fromFPGA(fpgaData->AccelerometerSampleTimestamp);
+	this->accelerometerData->rawAccelerometer[0] = fpgaData->AccelerometerRaw1;
+	this->accelerometerData->rawAccelerometer[1] = fpgaData->AccelerometerRaw2;
+	this->accelerometerData->rawAccelerometer[2] = fpgaData->AccelerometerRaw3;
+	this->accelerometerData->rawAccelerometer[3] = fpgaData->AccelerometerRaw4;
+	this->accelerometerData->rawAccelerometer[4] = fpgaData->AccelerometerRaw5;
+	this->accelerometerData->rawAccelerometer[5] = fpgaData->AccelerometerRaw6;
+	this->accelerometerData->rawAccelerometer[6] = fpgaData->AccelerometerRaw7;
+	this->accelerometerData->rawAccelerometer[7] = fpgaData->AccelerometerRaw8;
 	this->accelerometerData->accelerometer[0] = ((this->accelerometerData->rawAccelerometer[0] - this->accelerometerSettings->AccelerometerBias[0]) * this->accelerometerSettings->AccelerometerSensitivity[0]) * this->accelerometerSettings->AccelerometerScalars[0] + this->accelerometerSettings->AccelerometerOffsets[0];
 	this->accelerometerData->accelerometer[1] = ((this->accelerometerData->rawAccelerometer[1] - this->accelerometerSettings->AccelerometerBias[1]) * this->accelerometerSettings->AccelerometerSensitivity[1]) * this->accelerometerSettings->AccelerometerScalars[1] + this->accelerometerSettings->AccelerometerOffsets[1];
 	this->accelerometerData->accelerometer[2] = ((this->accelerometerData->rawAccelerometer[2] - this->accelerometerSettings->AccelerometerBias[2]) * this->accelerometerSettings->AccelerometerSensitivity[2]) * this->accelerometerSettings->AccelerometerScalars[2] + this->accelerometerSettings->AccelerometerOffsets[2];

--- a/Controller/src/LSST/M1M3/SS/Accelerometer/Accelerometer.h
+++ b/Controller/src/LSST/M1M3/SS/Accelerometer/Accelerometer.h
@@ -16,7 +16,6 @@ namespace M1M3 {
 namespace SS {
 
 class AccelerometerSettings;
-struct SupportFPGAData;
 class M1M3SSPublisher;
 
 /*!
@@ -25,7 +24,6 @@ class M1M3SSPublisher;
 class Accelerometer {
 private:
 	AccelerometerSettings* accelerometerSettings;
-	SupportFPGAData* fpgaData;
 	M1M3SSPublisher* publisher;
 
 	MTM1M3_accelerometerDataC* accelerometerData;
@@ -35,10 +33,9 @@ public:
 	/*!
 	 * Instantiates the accelerometer.
 	 * @param[in] accelerometerSettings The accelerometer settings.
-	 * @param[in] fpgaData The fpga data.
 	 * @param[in] publisher The publisher.
 	 */
-	Accelerometer(AccelerometerSettings* accelerometerSettings, SupportFPGAData* fpgaData, M1M3SSPublisher* publisher);
+	Accelerometer(AccelerometerSettings* accelerometerSettings, M1M3SSPublisher* publisher);
 
 	/*!
 	 * Processes currently available accelerometer data and publish it.

--- a/Controller/src/LSST/M1M3/SS/DigitalInputOutput/DigitalInputOutput.h
+++ b/Controller/src/LSST/M1M3/SS/DigitalInputOutput/DigitalInputOutput.h
@@ -9,6 +9,7 @@
 #define DIGITALINPUTOUTPUT_H_
 
 #include <DataTypes.h>
+#include <IFPGA.h>
 
 struct MTM1M3_logevent_airSupplyStatusC;
 struct MTM1M3_logevent_airSupplyWarningC;
@@ -22,7 +23,6 @@ namespace M1M3 {
 namespace SS {
 
 class InterlockApplicationSettings;
-class FPGA;
 struct SupportFPGAData;
 class M1M3SSPublisher;
 class SafetyController;
@@ -33,8 +33,6 @@ class SafetyController;
 class DigitalInputOutput {
 private:
 	InterlockApplicationSettings* interlockApplicationSettings;
-	FPGA* fpga;
-	SupportFPGAData* fpgaData;
 	M1M3SSPublisher* publisher;
 	SafetyController* safetyController;
 
@@ -54,10 +52,9 @@ public:
 	/*!
 	 * Instantiates the accelerometer.
 	 * @param[in] accelerometerSettings The accelerometer settings.
-	 * @param[in] fpga The fpga.
 	 * @param[in] publisher The publisher.
 	 */
-	DigitalInputOutput(InterlockApplicationSettings* interlockApplicationSettings, FPGA* fpga, M1M3SSPublisher* publisher);
+	DigitalInputOutput(InterlockApplicationSettings* interlockApplicationSettings, M1M3SSPublisher* publisher);
 
 	/*!
 	 * Sets the safety controller.

--- a/Controller/src/LSST/M1M3/SS/FPGA/ExpansionFPGA.cpp
+++ b/Controller/src/LSST/M1M3/SS/FPGA/ExpansionFPGA.cpp
@@ -15,9 +15,8 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-ExpansionFPGA::ExpansionFPGA(ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings) {
+ExpansionFPGA::ExpansionFPGA() {
 	Log.Debug("ExpansionFPGA: ExpansionFPGA()");
-	this->expansionFPGAApplicationSettings = expansionFPGAApplicationSettings;
 	this->session = 0;
 	this->remaining = 0;
 }

--- a/Controller/src/LSST/M1M3/SS/FPGA/ExpansionFPGA.h
+++ b/Controller/src/LSST/M1M3/SS/FPGA/ExpansionFPGA.h
@@ -1,41 +1,33 @@
-/*
- * ExpansionFPGA.h
- *
- *  Created on: Jan 9, 2018
- *      Author: ccontaxis
- */
-
 #ifndef EXPANSIONFPGA_H_
 #define EXPANSIONFPGA_H_
 
 #include <NiFpga.h>
 
+#include <IExpansionFPGA.h>
+
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-class ExpansionFPGAApplicationSettings;
-
-class ExpansionFPGA {
-private:
-	ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings;
-	uint32_t session;
-	size_t remaining;
-
+class ExpansionFPGA : public IExpansionFPGA {
 public:
-	ExpansionFPGA(ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings);
+    ExpansionFPGA();
 
-	int32_t initialize();
-	int32_t open();
-	int32_t close();
-	int32_t finalize();
+    int32_t initialize() override;
+    int32_t open() override;
+    int32_t close() override;
+    int32_t finalize() override;
 
-	bool isErrorCode(int32_t status);
+    bool isErrorCode(int32_t status) override;
 
-	int32_t sample();
+    int32_t sample() override;
 
-	int32_t readSlot1(float* data);
-	int32_t readSlot2(uint32_t* data);
+    int32_t readSlot1(float* data) override;
+    int32_t readSlot2(uint32_t* data) override;
+
+private:
+    uint32_t session;
+    size_t remaining;
 };
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/FPGA/FPGA.h
+++ b/Controller/src/LSST/M1M3/SS/FPGA/FPGA.h
@@ -1,14 +1,8 @@
-/*
- * FPGA.h
- *
- *  Created on: Sep 28, 2017
- *      Author: ccontaxis
- */
-
 #ifndef FPGA_H_
 #define FPGA_H_
 
 #include <NiFpga.h>
+#include <IFPGA.h>
 #include <SupportFPGAData.h>
 
 namespace LSST {
@@ -18,47 +12,47 @@ namespace SS {
 /*!
  * The class used to communicate with the FPGA.
  */
-class FPGA {
+class FPGA : public IFPGA {
 private:
-	uint32_t session;
-	size_t remaining;
-	uint16_t u16Buffer[1];
-	NiFpga_IrqContext outerLoopIRQContext;
-	NiFpga_IrqContext modbusIRQContext;
-	NiFpga_IrqContext ppsIRQContext;
-	SupportFPGAData supportFPGAData;
+    uint32_t session;
+    size_t remaining;
+    uint16_t u16Buffer[1];
+    NiFpga_IrqContext outerLoopIRQContext;
+    NiFpga_IrqContext modbusIRQContext;
+    NiFpga_IrqContext ppsIRQContext;
+    SupportFPGAData supportFPGAData;
 
 public:
-	FPGA();
-	virtual ~FPGA();
+    FPGA();
+    virtual ~FPGA();
 
-	SupportFPGAData* getSupportFPGAData() { return &this->supportFPGAData; }
+    SupportFPGAData* getSupportFPGAData() override { return &this->supportFPGAData; }
 
-	int32_t initialize();
-	int32_t open();
-	int32_t close();
-	int32_t finalize();
+    int32_t initialize() override;
+    int32_t open() override;
+    int32_t close() override;
+    int32_t finalize() override;
 
-	bool isErrorCode(int32_t status);
+    bool isErrorCode(int32_t status) override;
 
-	int32_t waitForOuterLoopClock(int32_t timeout);
-	int32_t ackOuterLoopClock();
+    int32_t waitForOuterLoopClock(int32_t timeout) override;
+    int32_t ackOuterLoopClock() override;
 
-	int32_t waitForPPS(int32_t timeout);
-	int32_t ackPPS();
+    int32_t waitForPPS(int32_t timeout) override;
+    int32_t ackPPS() override;
 
-	int32_t waitForModbusIRQ(int32_t subnet, int32_t timeout);
-	int32_t ackModbusIRQ(int32_t subnet);
+    int32_t waitForModbusIRQ(int32_t subnet, int32_t timeout) override;
+    int32_t ackModbusIRQ(int32_t subnet) override;
 
-	void pullTelemetry();
+    void pullTelemetry() override;
 
-	int32_t writeCommandFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs);
-	int32_t writeCommandFIFO(uint16_t data, int32_t timeoutInMs);
-	int32_t writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs);
-	int32_t writeRequestFIFO(uint16_t data, int32_t timeoutInMs);
-	int32_t writeTimestampFIFO(uint64_t timestamp);
-	int32_t readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs);
-	int32_t readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs);
+    int32_t writeCommandFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) override;
+    int32_t writeCommandFIFO(uint16_t data, int32_t timeoutInMs) override;
+    int32_t writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) override;
+    int32_t writeRequestFIFO(uint16_t data, int32_t timeoutInMs) override;
+    int32_t writeTimestampFIFO(uint64_t timestamp) override;
+    int32_t readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs) override;
+    int32_t readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) override;
 };
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/FPGA/IExpansionFPGA.cpp
+++ b/Controller/src/LSST/M1M3/SS/FPGA/IExpansionFPGA.cpp
@@ -1,31 +1,19 @@
-/*
- * IExpansionFPGA.cpp
- *
- *  Created on: Nov 1, 2018
- *      Author: ccontaxis
- */
-
 #include <IExpansionFPGA.h>
 
-namespace LSST {
-namespace M1M3 {
-namespace SS {
+#ifdef SIMULATOR
+#include <SimulatedExpansionFPGA.h>
+#else
+#include <ExpansionFPGA.h>
+#endif
 
-IExpansionFPGA::IExpansionFPGA() { }
-IExpansionFPGA::~IExpansionFPGA() { }
+using namespace LSST::M1M3::SS;
 
-int32_t IExpansionFPGA::initialize() { return 0; }
-int32_t IExpansionFPGA::open() { return 0; }
-int32_t IExpansionFPGA::close() { return 0; }
-int32_t IExpansionFPGA::finalize() { return 0; }
-
-bool IExpansionFPGA::isErrorCode(int32_t status) { return 0; }
-
-int32_t IExpansionFPGA::sample() { return 0; }
-
-int32_t IExpansionFPGA::readSlot1(float* data) { return 0; }
-int32_t IExpansionFPGA::readSlot2(uint32_t* data) { return 0; }
-
-} /* namespace SS */
-} /* namespace M1M3 */
-} /* namespace LSST */
+IExpansionFPGA& IExpansionFPGA::get() {
+#ifdef SIMULATOR
+    static SimulatedExpansionFPGA sexpansionfpga;
+    return sexpansionfpga;
+#else
+    static ExpansionFPGA expansionfpga;
+    return expansionfpga;
+#endif
+}

--- a/Controller/src/LSST/M1M3/SS/FPGA/IExpansionFPGA.h
+++ b/Controller/src/LSST/M1M3/SS/FPGA/IExpansionFPGA.h
@@ -1,35 +1,42 @@
-/*
- * IExpansionFPGA.h
- *
- *  Created on: Nov 1, 2018
- *      Author: ccontaxis
- */
-
 #ifndef LSST_M1M3_SS_FPGA_IEXPANSIONFPGA_H_
 #define LSST_M1M3_SS_FPGA_IEXPANSIONFPGA_H_
 
 #include <NiFpga.h>
+#include <ExpansionFPGAApplicationSettings.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Abstract singleton class for expansion FPGA.
+ */
 class IExpansionFPGA {
 public:
-	IExpansionFPGA();
-	virtual ~IExpansionFPGA();
+    IExpansionFPGA() { this->expansionFPGAApplicationSettings = NULL; };
+    virtual ~IExpansionFPGA(){};
 
-	virtual int32_t initialize();
-	virtual int32_t open();
-	virtual int32_t close();
-	virtual int32_t finalize();
+    static IExpansionFPGA& get();
 
-	virtual bool isErrorCode(int32_t status);
+    void setExpansionFPGAApplicationSettings(
+            ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings) {
+        this->expansionFPGAApplicationSettings = expansionFPGAApplicationSettings;
+    }
 
-	virtual int32_t sample();
+    virtual int32_t initialize() = 0;
+    virtual int32_t open() = 0;
+    virtual int32_t close() = 0;
+    virtual int32_t finalize() = 0;
 
-	virtual int32_t readSlot1(float* data);
-	virtual int32_t readSlot2(uint32_t* data);
+    virtual bool isErrorCode(int32_t status) = 0;
+
+    virtual int32_t sample() = 0;
+
+    virtual int32_t readSlot1(float* data) = 0;
+    virtual int32_t readSlot2(uint32_t* data) = 0;
+
+protected:
+    ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings;
 };
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/FPGA/IFPGA.cpp
+++ b/Controller/src/LSST/M1M3/SS/FPGA/IFPGA.cpp
@@ -1,47 +1,19 @@
-/*
- * IFPGA.cpp
- *
- *  Created on: Nov 2, 2018
- *      Author: ccontaxis
- */
-
 #include <IFPGA.h>
 
-namespace LSST {
-namespace M1M3 {
-namespace SS {
+#ifdef SIMULATOR
+#include <SimulatedFPGA.h>
+#else
+#include <FPGA.h>
+#endif
 
-IFPGA::IFPGA() { }
-IFPGA::~IFPGA() { }
+using namespace LSST::M1M3::SS;
 
-SupportFPGAData* IFPGA::getSupportFPGAData() { return 0; }
-
-int32_t IFPGA::initialize() { return 0; }
-int32_t IFPGA::open() { return 0; }
-int32_t IFPGA::close() { return 0; }
-int32_t IFPGA::finalize() { return 0; }
-
-bool IFPGA::isErrorCode(int32_t status) { return 0; }
-
-int32_t IFPGA::waitForOuterLoopClock(int32_t timeout) { return 0; }
-int32_t IFPGA::ackOuterLoopClock() { return 0; }
-
-int32_t IFPGA::waitForPPS(int32_t timeout) { return 0; }
-int32_t IFPGA::ackPPS() { return 0; }
-
-int32_t IFPGA::waitForModbusIRQ(int32_t subnet, int32_t timeout) { return 0; }
-int32_t IFPGA::ackModbusIRQ(int32_t subnet) { return 0; }
-
-void IFPGA::pullTelemetry() { }
-
-int32_t IFPGA::writeCommandFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) { return 0; }
-int32_t IFPGA::writeCommandFIFO(uint16_t data, int32_t timeoutInMs) { return 0; }
-int32_t IFPGA::writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) { return 0; }
-int32_t IFPGA::writeRequestFIFO(uint16_t data, int32_t timeoutInMs) { return 0; }
-int32_t IFPGA::writeTimestampFIFO(uint64_t timestamp) { return 0; }
-int32_t IFPGA::readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs) { return 0; }
-int32_t IFPGA::readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) { return 0; }
-
-} /* namespace SS */
-} /* namespace M1M3 */
-} /* namespace LSST */
+IFPGA& IFPGA::get() {
+#ifdef SIMULATOR
+    static SimulatedFPGA simulatedfpga;
+    return simulatedfpga;
+#else
+    static FPGA fpga;
+    return fpga;
+#endif
+}

--- a/Controller/src/LSST/M1M3/SS/FPGA/IFPGA.h
+++ b/Controller/src/LSST/M1M3/SS/FPGA/IFPGA.h
@@ -1,10 +1,3 @@
-/*
- * IFPGA.h
- *
- *  Created on: Nov 2, 2018
- *      Author: ccontaxis
- */
-
 #ifndef LSST_M1M3_SS_FPGA_IFPGA_H_
 #define LSST_M1M3_SS_FPGA_IFPGA_H_
 
@@ -15,38 +8,44 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Abstract interface for FPGA. Both real FPGA and simulated class implements
+ * this. Singleton.
+ */
 class IFPGA {
 public:
-	IFPGA();
-	virtual ~IFPGA();
+    IFPGA(){};
+    virtual ~IFPGA(){};
 
-	virtual SupportFPGAData* getSupportFPGAData();
+    static IFPGA& get();
 
-	virtual int32_t initialize();
-	virtual int32_t open();
-	virtual int32_t close();
-	virtual int32_t finalize();
+    virtual SupportFPGAData* getSupportFPGAData() = 0;
 
-	virtual bool isErrorCode(int32_t status);
+    virtual int32_t initialize() = 0;
+    virtual int32_t open() = 0;
+    virtual int32_t close() = 0;
+    virtual int32_t finalize() = 0;
 
-	virtual int32_t waitForOuterLoopClock(int32_t timeout);
-	virtual int32_t ackOuterLoopClock();
+    virtual bool isErrorCode(int32_t status) = 0;
 
-	virtual int32_t waitForPPS(int32_t timeout);
-	virtual int32_t ackPPS();
+    virtual int32_t waitForOuterLoopClock(int32_t timeout) = 0;
+    virtual int32_t ackOuterLoopClock() = 0;
 
-	virtual int32_t waitForModbusIRQ(int32_t subnet, int32_t timeout);
-	virtual int32_t ackModbusIRQ(int32_t subnet);
+    virtual int32_t waitForPPS(int32_t timeout) = 0;
+    virtual int32_t ackPPS() = 0;
 
-	virtual void pullTelemetry();
+    virtual int32_t waitForModbusIRQ(int32_t subnet, int32_t timeout) = 0;
+    virtual int32_t ackModbusIRQ(int32_t subnet) = 0;
 
-	virtual int32_t writeCommandFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs);
-	virtual int32_t writeCommandFIFO(uint16_t data, int32_t timeoutInMs);
-	virtual int32_t writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs);
-	virtual int32_t writeRequestFIFO(uint16_t data, int32_t timeoutInMs);
-	virtual int32_t writeTimestampFIFO(uint64_t timestamp);
-	virtual int32_t readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs);
-	virtual int32_t readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs);
+    virtual void pullTelemetry() = 0;
+
+    virtual int32_t writeCommandFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) = 0;
+    virtual int32_t writeCommandFIFO(uint16_t data, int32_t timeoutInMs) = 0;
+    virtual int32_t writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) = 0;
+    virtual int32_t writeRequestFIFO(uint16_t data, int32_t timeoutInMs) = 0;
+    virtual int32_t writeTimestampFIFO(uint64_t timestamp) = 0;
+    virtual int32_t readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs) = 0;
+    virtual int32_t readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) = 0;
 };
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/FPGA/SimulatedExpansionFPGA.h
+++ b/Controller/src/LSST/M1M3/SS/FPGA/SimulatedExpansionFPGA.h
@@ -1,10 +1,3 @@
-/*
- * SimulatedExpansionFPGA.h
- *
- *  Created on: Nov 1, 2018
- *      Author: ccontaxis
- */
-
 #ifndef LSST_M1M3_SS_FPGA_SIMULATEDEXPANSIONFPGA_H_
 #define LSST_M1M3_SS_FPGA_SIMULATEDEXPANSIONFPGA_H_
 
@@ -17,25 +10,26 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-class SimulatedExpansionFPGA: public IExpansionFPGA {
-private:
-	float rnd[RND_CNT];
-	int rndIndex;
-	float getRnd();
+class SimulatedExpansionFPGA : public IExpansionFPGA {
 public:
-	SimulatedExpansionFPGA();
+    SimulatedExpansionFPGA();
 
-	int32_t initialize();
-	int32_t open();
-	int32_t close();
-	int32_t finalize();
+    int32_t initialize() override;
+    int32_t open() override;
+    int32_t close() override;
+    int32_t finalize() override;
 
-	bool isErrorCode(int32_t status);
+    bool isErrorCode(int32_t status) override;
 
-	int32_t sample();
+    int32_t sample() override;
 
-	int32_t readSlot1(float* data);
-	int32_t readSlot2(uint32_t* data);
+    int32_t readSlot1(float* data) override;
+    int32_t readSlot2(uint32_t* data) override;
+
+private:
+    float rnd[RND_CNT];
+    int rndIndex;
+    float getRnd();
 };
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
+++ b/Controller/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
@@ -22,911 +22,928 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-SimulatedFPGA::SimulatedFPGA(M1M3SSPublisher* publisher, MTMount_AltC* tmaElevation, MTMount_AzC* tmaAzimuth, ForceActuatorApplicationSettings* forceActuatorApplicationSettings) {
-	Log.Info("SimulatedFPGA: SimulatedFPGA()");
-	this->publisher = publisher;
-	this->tmaElevation = tmaElevation;
-	this->forceActuatorApplicationSettings = forceActuatorApplicationSettings;
-	this->tmaAzimuth = tmaAzimuth;
-	this->appliedCylinderForces = this->publisher->getEventAppliedCylinderForces();
-	this->hardpointActuatorData = this->publisher->getHardpointActuatorData();
-//	this->appliedHardpointSteps = this->publisher->getEventAppliedHardpointSteps();
-	this->outerLoopData = this->publisher->getOuterLoopData();
-	this->lastRequest = -1;
-	memset(&this->supportFPGAData, 0, sizeof(SupportFPGAData));
-	this->supportFPGAData.DigitalInputStates = 0x0001 | 0x0002 | 0x0008 | 0x0010 | 0x0040 | 0x0080;
-	this->hardpointActuatorData->encoder[0] = 15137;
-	this->hardpointActuatorData->encoder[1] = 20079;
-	this->hardpointActuatorData->encoder[2] = 26384;
-	this->hardpointActuatorData->encoder[3] = 27424;
-	this->hardpointActuatorData->encoder[4] = 17560;
-	this->hardpointActuatorData->encoder[5] = 23546;
-	for(int i = 0; i < RND_CNT; ++i) {
-		this->rnd[i] = float((rand() % 2000) - 1000) / 1000.0;
-	}
-	this->rndIndex = 0;
+SimulatedFPGA::SimulatedFPGA() {
+    Log.Info("SimulatedFPGA: SimulatedFPGA()");
+    this->publisher = NULL;
+    this->forceActuatorApplicationSettings = NULL;
+    this->lastRequest = -1;
+    memset(&supportFPGAData, 0, sizeof(SupportFPGAData));
+    supportFPGAData.DigitalInputStates = 0x0001 | 0x0002 | 0x0008 | 0x0010 | 0x0040 | 0x0080;
+    for (int i = 0; i < RND_CNT; ++i) {
+        this->rnd[i] = float((rand() % 2000) - 1000) / 1000.0;
+    }
+    this->rndIndex = 0;
 }
 
-float SimulatedFPGA::getRnd() {
-	++this->rndIndex;
-	if (this->rndIndex > RND_CNT) {
-		this->rndIndex = 0;
-	}
-	return this->rnd[rndIndex];
+void SimulatedFPGA::setPublisher(M1M3SSPublisher* publisher) {
+    this->publisher = publisher;
+    MTM1M3_hardpointActuatorDataC* hardpointActuatorData = this->publisher->getHardpointActuatorData();
+    hardpointActuatorData->encoder[0] = 15137;
+    hardpointActuatorData->encoder[1] = 20079;
+    hardpointActuatorData->encoder[2] = 26384;
+    hardpointActuatorData->encoder[3] = 27424;
+    hardpointActuatorData->encoder[4] = 17560;
+    hardpointActuatorData->encoder[5] = 23546;
+}
+
+void SimulatedFPGA::setForceActuatorApplicationSettings(
+        ForceActuatorApplicationSettings* forceActuatorApplicationSettings) {
+    this->forceActuatorApplicationSettings = forceActuatorApplicationSettings;
 }
 
 int32_t SimulatedFPGA::initialize() {
-	Log.Debug("SimulatedFPGA: initialize()");
-	return 0;
+    Log.Debug("SimulatedFPGA: initialize()");
+    return 0;
 }
 
 int32_t SimulatedFPGA::open() {
-	Log.Debug("SimulatedFPGA: open()");
-	return 0;
+    Log.Debug("SimulatedFPGA: open()");
+    return 0;
 }
 
 int32_t SimulatedFPGA::close() {
-	Log.Debug("SimulatedFPGA: close()");
-	return 0;
+    Log.Debug("SimulatedFPGA: close()");
+    return 0;
 }
 
 int32_t SimulatedFPGA::finalize() {
-	Log.Debug("SimulatedFPGA: finalize()");
-	return 0;
+    Log.Debug("SimulatedFPGA: finalize()");
+    return 0;
 }
 
-bool SimulatedFPGA::isErrorCode(int32_t status) {
-	return status != 0;
-}
+bool SimulatedFPGA::isErrorCode(int32_t status) { return status != 0; }
 
 int32_t SimulatedFPGA::waitForOuterLoopClock(int32_t timeout) {
-	usleep(20000);
-	return 0;
+    usleep(20000);
+    return 0;
 }
 
-int32_t SimulatedFPGA::ackOuterLoopClock() {
-	return 0;
-}
+int32_t SimulatedFPGA::ackOuterLoopClock() { return 0; }
 
 int32_t SimulatedFPGA::waitForPPS(int32_t timeout) {
-	usleep(1000000);
-	return 0;
+    usleep(1000000);
+    return 0;
 }
 
-int32_t SimulatedFPGA::ackPPS() {
-	return 0;
-}
+int32_t SimulatedFPGA::ackPPS() { return 0; }
 
-int32_t SimulatedFPGA::waitForModbusIRQ(int32_t subnet, int32_t timeout) {
-	return 0;
-}
+int32_t SimulatedFPGA::waitForModbusIRQ(int32_t subnet, int32_t timeout) { return 0; }
 
-int32_t SimulatedFPGA::ackModbusIRQ(int32_t subnet) {
-	return 0;
-}
+int32_t SimulatedFPGA::ackModbusIRQ(int32_t subnet) { return 0; }
 
 void SimulatedFPGA::pullTelemetry() {
-	Log.Trace("SimulatedFPGA: pullTelemetry()");
-	uint64_t timestamp = Timestamp::toRaw(this->publisher->getTimestamp());
-	this->supportFPGAData.Reserved = 0;
-	this->supportFPGAData.InclinometerTxBytes = 0;
-	this->supportFPGAData.InclinometerRxBytes = 0;
-	this->supportFPGAData.InclinometerTxFrames = 0;
-	this->supportFPGAData.InclinometerRxFrames = 0;
-	this->supportFPGAData.InclinometerErrorTimestamp = 0;
-	this->supportFPGAData.InclinometerErrorCode = 0;
-	this->supportFPGAData.InclinometerSampleTimestamp = timestamp;
-	this->supportFPGAData.InclinometerAngleRaw = (int32_t)(this->tmaElevation->Elevation_Angle_Actual * 1000.0) + (this->getRnd() * 5.0);
-	this->supportFPGAData.DisplacementTxBytes = 0;
-	this->supportFPGAData.DisplacementRxBytes = 0;
-	this->supportFPGAData.DisplacementTxFrames = 0;
-	this->supportFPGAData.DisplacementRxFrames = 0;
-	this->supportFPGAData.DisplacementErrorTimestamp = 0;
-	this->supportFPGAData.DisplacementErrorCode = 0;
-	this->supportFPGAData.DisplacementSampleTimestamp = timestamp;
-	this->supportFPGAData.DisplacementRaw1 = (int32_t)(this->getRnd() + 10) * 1000.0;
-	this->supportFPGAData.DisplacementRaw2 = (int32_t)(this->getRnd() + 20) * 1000.0;
-	this->supportFPGAData.DisplacementRaw3 = (int32_t)(this->getRnd() + 30) * 1000.0;
-	this->supportFPGAData.DisplacementRaw4 = (int32_t)(this->getRnd() + 40) * 1000.0;
-	this->supportFPGAData.DisplacementRaw5 = (int32_t)(this->getRnd() + 50) * 1000.0;
-	this->supportFPGAData.DisplacementRaw6 = (int32_t)(this->getRnd() + 60) * 1000.0;
-	this->supportFPGAData.DisplacementRaw7 = (int32_t)(this->getRnd() + 70) * 1000.0;
-	this->supportFPGAData.DisplacementRaw8 = (int32_t)(this->getRnd() + 80) * 1000.0;
-	this->supportFPGAData.AccelerometerSampleCount++;
-	this->supportFPGAData.AccelerometerSampleTimestamp = timestamp;
-	this->supportFPGAData.AccelerometerRaw1 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw2 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw3 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw4 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw5 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw6 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw7 = this->getRnd() * 0.01;
-	this->supportFPGAData.AccelerometerRaw8 = this->getRnd() * 0.01;
-	this->supportFPGAData.GyroTxBytes = 0;
-	this->supportFPGAData.GyroRxBytes = 0;
-	this->supportFPGAData.GyroTxFrames = 0;
-	this->supportFPGAData.GyroRxFrames = 0;
-	this->supportFPGAData.GyroErrorTimestamp = 0;
-	this->supportFPGAData.GyroErrorCode = 0;
-	this->supportFPGAData.GyroSampleTimestamp = timestamp;
-	this->supportFPGAData.GyroRawX = this->getRnd() * 0.01;
-	this->supportFPGAData.GyroRawY = this->getRnd() * 0.01;
-	this->supportFPGAData.GyroRawZ = this->getRnd() * 0.01;
-	this->supportFPGAData.GyroStatus = 0x7F;
-	this->supportFPGAData.GyroSequenceNumber++;
-	if (this->supportFPGAData.GyroSequenceNumber > 127) {
-		this->supportFPGAData.GyroSequenceNumber = 0;
-	}
-	this->supportFPGAData.GyroTemperature = 24 + int(this->getRnd() * 2);
-	this->supportFPGAData.GyroBITTimestamp = timestamp;
-	this->supportFPGAData.GyroBIT0 = 0x7F;
-	this->supportFPGAData.GyroBIT1 = 0x7F;
-	this->supportFPGAData.GyroBIT2 = 0x7F;
-	this->supportFPGAData.GyroBIT3 = 0x7F;
-	this->supportFPGAData.GyroBIT4 = 0x7F;
-	this->supportFPGAData.GyroBIT5 = 0x7F;
-	this->supportFPGAData.GyroBIT6 = 0x7F;
-	this->supportFPGAData.GyroBIT7 = 0x7F;
-	this->supportFPGAData.DigitalInputSampleCount++;
-	this->supportFPGAData.DigitalInputTimestamp = timestamp;
-//	this->supportFPGAData.DigitalInputStates = 0;
-	this->supportFPGAData.DigitalOutputSampleCount++;
-	this->supportFPGAData.DigitalOutputTimestamp = timestamp;
-//	this->supportFPGAData.DigitalOutputStates = 0;
-	this->supportFPGAData.PowerSupplySampleCount++;
-	this->supportFPGAData.PowerSupplyTimestamp = timestamp;
-//	this->supportFPGAData.PowerSupplyStates = 0;
+    Log.Trace("SimulatedFPGA: pullTelemetry()");
+    uint64_t timestamp = Timestamp::toRaw(this->publisher->getTimestamp());
+    this->supportFPGAData.Reserved = 0;
+    this->supportFPGAData.InclinometerTxBytes = 0;
+    this->supportFPGAData.InclinometerRxBytes = 0;
+    this->supportFPGAData.InclinometerTxFrames = 0;
+    this->supportFPGAData.InclinometerRxFrames = 0;
+    this->supportFPGAData.InclinometerErrorTimestamp = 0;
+    this->supportFPGAData.InclinometerErrorCode = 0;
+    this->supportFPGAData.InclinometerSampleTimestamp = timestamp;
+    this->supportFPGAData.InclinometerAngleRaw =
+            (int32_t)(tmaElevation.position * 1000.0) + (this->getRnd() * 5.0);
+    this->supportFPGAData.DisplacementTxBytes = 0;
+    this->supportFPGAData.DisplacementRxBytes = 0;
+    this->supportFPGAData.DisplacementTxFrames = 0;
+    this->supportFPGAData.DisplacementRxFrames = 0;
+    this->supportFPGAData.DisplacementErrorTimestamp = 0;
+    this->supportFPGAData.DisplacementErrorCode = 0;
+    this->supportFPGAData.DisplacementSampleTimestamp = timestamp;
+    this->supportFPGAData.DisplacementRaw1 = (int32_t)(this->getRnd() + 10) * 1000.0;
+    this->supportFPGAData.DisplacementRaw2 = (int32_t)(this->getRnd() + 20) * 1000.0;
+    this->supportFPGAData.DisplacementRaw3 = (int32_t)(this->getRnd() + 30) * 1000.0;
+    this->supportFPGAData.DisplacementRaw4 = (int32_t)(this->getRnd() + 40) * 1000.0;
+    this->supportFPGAData.DisplacementRaw5 = (int32_t)(this->getRnd() + 50) * 1000.0;
+    this->supportFPGAData.DisplacementRaw6 = (int32_t)(this->getRnd() + 60) * 1000.0;
+    this->supportFPGAData.DisplacementRaw7 = (int32_t)(this->getRnd() + 70) * 1000.0;
+    this->supportFPGAData.DisplacementRaw8 = (int32_t)(this->getRnd() + 80) * 1000.0;
+    this->supportFPGAData.AccelerometerSampleCount++;
+    this->supportFPGAData.AccelerometerSampleTimestamp = timestamp;
+    this->supportFPGAData.AccelerometerRaw1 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw2 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw3 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw4 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw5 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw6 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw7 = this->getRnd() * 0.01;
+    this->supportFPGAData.AccelerometerRaw8 = this->getRnd() * 0.01;
+    this->supportFPGAData.GyroTxBytes = 0;
+    this->supportFPGAData.GyroRxBytes = 0;
+    this->supportFPGAData.GyroTxFrames = 0;
+    this->supportFPGAData.GyroRxFrames = 0;
+    this->supportFPGAData.GyroErrorTimestamp = 0;
+    this->supportFPGAData.GyroErrorCode = 0;
+    this->supportFPGAData.GyroSampleTimestamp = timestamp;
+    this->supportFPGAData.GyroRawX = this->getRnd() * 0.01;
+    this->supportFPGAData.GyroRawY = this->getRnd() * 0.01;
+    this->supportFPGAData.GyroRawZ = this->getRnd() * 0.01;
+    this->supportFPGAData.GyroStatus = 0x7F;
+    this->supportFPGAData.GyroSequenceNumber++;
+    if (this->supportFPGAData.GyroSequenceNumber > 127) {
+        this->supportFPGAData.GyroSequenceNumber = 0;
+    }
+    this->supportFPGAData.GyroTemperature = 24 + int(this->getRnd() * 2);
+    this->supportFPGAData.GyroBITTimestamp = timestamp;
+    this->supportFPGAData.GyroBIT0 = 0x7F;
+    this->supportFPGAData.GyroBIT1 = 0x7F;
+    this->supportFPGAData.GyroBIT2 = 0x7F;
+    this->supportFPGAData.GyroBIT3 = 0x7F;
+    this->supportFPGAData.GyroBIT4 = 0x7F;
+    this->supportFPGAData.GyroBIT5 = 0x7F;
+    this->supportFPGAData.GyroBIT6 = 0x7F;
+    this->supportFPGAData.GyroBIT7 = 0x7F;
+    this->supportFPGAData.DigitalInputSampleCount++;
+    this->supportFPGAData.DigitalInputTimestamp = timestamp;
+    //	this->supportFPGAData.DigitalInputStates = 0;
+    this->supportFPGAData.DigitalOutputSampleCount++;
+    this->supportFPGAData.DigitalOutputTimestamp = timestamp;
+    //	this->supportFPGAData.DigitalOutputStates = 0;
+    this->supportFPGAData.PowerSupplySampleCount++;
+    this->supportFPGAData.PowerSupplyTimestamp = timestamp;
+    //	this->supportFPGAData.PowerSupplyStates = 0;
 }
 
 int32_t SimulatedFPGA::writeCommandFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) {
-	for(int i = 0; i < length;) {
-		uint16_t signal = data[i++];
-		uint16_t dataLength = 0;
-		uint16_t subnet = 0;
-		std::queue<uint16_t>* response = 0;
-		switch(signal) {
-		case FPGAAddresses::AccelerometerAx:
-		case FPGAAddresses::AccelerometerAz:
-		case FPGAAddresses::AccelerometerBy:
-		case FPGAAddresses::AccelerometerBz:
-		case FPGAAddresses::AccelerometerCx:
-		case FPGAAddresses::AccelerometerCz:
-		case FPGAAddresses::AccelerometerDy:
-		case FPGAAddresses::AccelerometerDz:
-			break;
-		case FPGAAddresses::ModbusSubnetATx:
-			subnet = 1;
-			response = &this->subnetAResponse;
-			dataLength = data[i++];
-			break;
-		case FPGAAddresses::ModbusSubnetBTx:
-			subnet = 2;
-			response = &this->subnetBResponse;
-			dataLength = data[i++];
-			break;
-		case FPGAAddresses::ModbusSubnetCTx:
-			subnet = 3;
-			response = &this->subnetCResponse;
-			dataLength = data[i++];
-			break;
-		case FPGAAddresses::ModbusSubnetDTx:
-			subnet = 4;
-			response = &this->subnetDResponse;
-			dataLength = data[i++];
-			break;
-		case FPGAAddresses::ModbusSubnetARx:
-		case FPGAAddresses::ModbusSubnetBRx:
-		case FPGAAddresses::ModbusSubnetCRx:
-		case FPGAAddresses::ModbusSubnetDRx:
-			break;
-		case FPGAAddresses::ModbusSubnetETx:
-			subnet = 5;
-			response = &this->subnetEResponse;
-			dataLength = data[i++];
-			break;
-		case FPGAAddresses::GyroTx: {
-			int size = data[i++]; // Read Tx Size
-			i += size; // Read All Tx Data
-			break;
-		}
-		case FPGAAddresses::ModbusSubnetERx:
-		case FPGAAddresses::GyroRx:
-			break;
-		case FPGAAddresses::ILCPowerInterlockStatus:
-		case FPGAAddresses::FanCoilerHeaterInterlockStatus:
-		case FPGAAddresses::AirSupplyInterlockStatus:
-		case FPGAAddresses::CabinetDoorInterlockStatus:
-		case FPGAAddresses::TMAMotionStopInterlockStatus:
-		case FPGAAddresses::GISHeartbeatInterlockStatus:
-		case FPGAAddresses::AirSupplyValveOpen:
-		case FPGAAddresses::AirSupplyValveClosed:
-		case FPGAAddresses::MirrorCellLightsOn:
-		case FPGAAddresses::HeartbeatToSafetyController: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.DigitalOutputStates & 0xFE) | (state ? 0x01 : 0x00);
-			break;
-		}
-		case FPGAAddresses::AirSupplyValveControl: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.DigitalOutputStates & 0xEF) | (state ? 0x00 : 0x10);
-			this->supportFPGAData.DigitalInputStates = (this->supportFPGAData.DigitalInputStates & 0xFCFF) | (state ? 0x0200 : 0x0100);
-			break;
-		}
-		case FPGAAddresses::MirrorCellLightControl: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.DigitalOutputStates & 0xDF) | (state ? 0x20 : 0x00);
-			this->supportFPGAData.DigitalInputStates = (this->supportFPGAData.DigitalInputStates & 0xFBFF) | (state ? 0x0400 : 0x0000);
-			break;
-		}
-		case FPGAAddresses::DCAuxPowerNetworkAOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xFE) | (state ? 0x01 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCAuxPowerNetworkBOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xFD) | (state ? 0x02 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCAuxPowerNetworkCOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xFB) | (state ? 0x04 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCAuxPowerNetworkDOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xF7) | (state ? 0x08 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCPowerNetworkAOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xEF) | (state ? 0x10 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCPowerNetworkBOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xDF) | (state ? 0x20 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCPowerNetworkCOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0xBF) | (state ? 0x40 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::DCPowerNetworkDOn: {
-			int state = data[i++];
-			this->supportFPGAData.DigitalOutputStates = (this->supportFPGAData.PowerSupplyStates & 0x7F) | (state ? 0x80 : 0x00);
-			// TODO: Set Power Supply Currents
-			break;
-		}
-		case FPGAAddresses::Displacement:
-		case FPGAAddresses::Inclinometer:
-		case FPGAAddresses::ModbusSoftwareTrigger:
-		case FPGAAddresses::Telemetry:
-		case FPGAAddresses::HealthAndStatus:
-		case FPGAAddresses::Timestamp:
-			break;
-		default: break;
-		}
-		if (response != 0) {
-			bool stepMotorBroadcast = false;
-			++i; // Read Software Trigger
-			// Response length is prepended at request
-			uint64_t rawTimestamp = Timestamp::toRaw(this->publisher->getTimestamp());
-			response->push((uint16_t)(rawTimestamp >> 48));
-			response->push((uint16_t)(rawTimestamp >> 32));
-			response->push((uint16_t)(rawTimestamp >> 16));
-			response->push((uint16_t)rawTimestamp); // Write Global Timestamp
-			int endIndex = i - 1 + dataLength - 1;
-			// The first -1 is for the software trigger
-			// The second -1 is for the trigger
-			while (i < endIndex) {
-				uint16_t address = this->readModbus(data[i++]); // Read Address
-				uint16_t function = this->readModbus(data[i++]); // Read Function Code
-				if (address == 248 && function == 66) {
-					stepMotorBroadcast = true;
-				}
-				if (address == 248 || address == 249) {
-					// This is a broadcast, no response, just read until 0xA000
-					while ((data[i] & 0xF000) != 0x2000) {
-						++i;
-					}
-					i--; // Shift to CRC for the remainder of the time
-					     // However broadcasts are followed by a timestamp
-					     // so only shift 1
-				}
-				else if (address == 0 && function == 0) {
-					// This is a special nop, read until 0xF000 != 0
-					while (data[i] == 0) {
-						++i;
-					}
-					i -= 4; // Shift to CRC for the rest of the parsing to work
-				}
-				else if (subnet >= 1 && subnet <= 4) {
-					int zIndex = -1;
-					for(int j = 0; j < FA_COUNT; ++j) {
-						if (this->forceActuatorApplicationSettings->Table[j].Subnet == subnet && this->forceActuatorApplicationSettings->Table[j].Address == address) {
-							zIndex = j;
-							break;
-						}
-					}
-					int pIndex = zIndex;
-					int sIndex = this->forceActuatorApplicationSettings->ZIndexToSecondaryCylinderIndex[zIndex];
-					switch(function) {
-					case 17: // Report Server Id
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 12); // Write Message Length
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, signal);
-						this->writeModbus(response, address); // Write ILC Unique Id
-						this->writeModbus(response, 0); // TODO: Write ILC Application Type
-						this->writeModbus(response, 0); // TODO: Write Network Node Type
-						this->writeModbus(response, 0); // TODO: Write ILC Selected Options
-						this->writeModbus(response, 0); // TODO: Write Network Node Options
-						this->writeModbus(response, 99); // TODO: Write Major Revision
-						this->writeModbus(response, 99); // TODO: Write Minor Revision
-						// TODO: Write Firmware Name
-						this->writeModbusCRC(response);
-						break;
-					case 18: // Report Server Status
-						this->writeModbus(response, address);
-						this->writeModbus(response, function);
-						this->writeModbus(response, 0); // TODO: Write IlC State
-						this->writeModbus(response, 0);
-						this->writeModbus(response, 0); // TODO: Write ILC Status
-						this->writeModbus(response, 0);
-						this->writeModbus(response, 0); // TODO: Write ILC Faults
-						this->writeModbusCRC(response);
-						break;
-					case 65: { // Change ILC Mode
-						++i; // Read Reserved Byte
-						uint16_t newMode = this->readModbus(data[i++]); // Read New Mode
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0); // Write Reserved Byte
-						this->writeModbus(response, newMode); // Write ILC State
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 73: // Set Boost Valve DCA Gains
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						i += 4; // Read Primary Cylinder DCA Gain
-						i += 4; // Read Secondary Cylinder DCA Gain
-						this->writeModbusCRC(response);
-						break;
-					case 74: { // Read Boost Valve DCA Gains
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						uint8_t buffer[4];
-						float gain = 1.0;
-						memcpy(buffer, &gain, 4);
-						this->writeModbus(response, buffer[3]);
-						this->writeModbus(response, buffer[2]);
-						this->writeModbus(response, buffer[1]);
-						this->writeModbus(response, buffer[0]); // Write Primary Cylinder DCA Gain
-						this->writeModbus(response, buffer[3]);
-						this->writeModbus(response, buffer[2]);
-						this->writeModbus(response, buffer[1]);
-						this->writeModbus(response, buffer[0]); // Write Secondary Cylinder DCA Gain
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 75: { // Force Demand
-						++i; // Read Slew Flag
-						uint16_t word1 = this->readModbus(data[i++]);
-						uint16_t word2 = this->readModbus(data[i++]);
-						uint16_t word3 = this->readModbus(data[i++]);
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, (uint8_t)this->outerLoopData->broadcastCounter); // Write ILC Status
-						uint8_t buffer[4];
-						float force = (((float)((word1 << 16) | (word2 << 8) | word3)) / 1000.0) + (this->getRnd() * 0.5);
-						memcpy(buffer, &force, 4);
-						this->writeModbus(response, buffer[3]);
-						this->writeModbus(response, buffer[2]);
-						this->writeModbus(response, buffer[1]);
-						this->writeModbus(response, buffer[0]); // Write Primary Cylinder Force
-						if (address > 16) {
-							word1 = this->readModbus(data[i++]);
-							word2 = this->readModbus(data[i++]);
-							word3 = this->readModbus(data[i++]);
-							force = (((float)((word1 << 16) | (word2 << 8) | word3)) / 1000.0) + (this->getRnd() * 0.5);
-							memcpy(buffer, &force, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write Secondary Cylinder Force
-						}
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 76: { // Force And Status
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, (uint8_t)this->outerLoopData->broadcastCounter); // Write ILC Status
-						uint8_t buffer[4];
-						float force = (((float)this->appliedCylinderForces->primaryCylinderForces[pIndex]) / 1000.0) + (this->getRnd() * 0.5); // Update to Primary Cylinder Force
-						memcpy(buffer, &force, 4);
-						this->writeModbus(response, buffer[3]);
-						this->writeModbus(response, buffer[2]);
-						this->writeModbus(response, buffer[1]);
-						this->writeModbus(response, buffer[0]); // Write Primary Cylinder Force
-						if (address > 16) {
-							force = (((float)this->appliedCylinderForces->secondaryCylinderForces[sIndex]) / 1000.0) + (this->getRnd() * 0.5); // Update to Secondary Cylinder Force
-							memcpy(buffer, &force, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write Secondary Cylinder Force
-						}
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 80: { // ADC Scan Rate
-						uint16_t scanRate = this->readModbus(data[i++]);
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, scanRate); // Write ADC Scan Rate
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 81: // ADC Channel Offset and Sensitivity
-						++i; // Read ADC Channel
-						i += 4; // Read Offset
-						i += 4; // Read Sensitivity
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbusCRC(response);
-						break;
-					case 107: // Reset
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbusCRC(response);
-						break;
-					case 110: { // Read Calibration
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						for(int j = 0; j < 24; ++j) {
-							uint8_t buffer[4];
-							float value = 0.0;
-							memcpy(buffer, &value, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write Calibration Data
-						}
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 119: { // Read DCA Pressure Values
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						for(int j = 0; j < 4; ++j) {
-							uint8_t buffer[4];
-							float value = 120.0;
-							memcpy(buffer, &value, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write DCA Pressure
-						}
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 120: // Read DCA Id
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x01);
-						this->writeModbus(response, signal);
-						this->writeModbus(response, address); // Write DCA Unique Id
-						this->writeModbus(response, 0); // TODO: Write DCA Firmware Type
-						this->writeModbus(response, 99); // TODO: Write Major Revision
-						this->writeModbus(response, 99); // TODO: Write Minor Revision
-						this->writeModbusCRC(response);
-						break;
-					case 121: // Read DCA Status
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00); // TODO: Write DCA Status
-						this->writeModbusCRC(response);
-						break;
-					default:
-						break;
-					}
-				}
-				else if (subnet == 5 && address >= 1 && address <= 6) {
-					switch(function) {
-					case 17: // Report Server Id
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 12); // Write Message Length
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, signal);
-						this->writeModbus(response, address); // Write ILC Unique Id
-						this->writeModbus(response, 0); // TODO: Write ILC Application Type
-						this->writeModbus(response, 0); // TODO: Write Network Node Type
-						this->writeModbus(response, 0); // TODO: Write ILC Selected Options
-						this->writeModbus(response, 0); // TODO: Write Network Node Options
-						this->writeModbus(response, 99); // TODO: Write Major Revision
-						this->writeModbus(response, 99); // TODO: Write Minor Revision
-						// TODO: Write Firmware Name
-						this->writeModbusCRC(response);
-						break;
-					case 18: // Report Server Status
-						this->writeModbus(response, address);
-						this->writeModbus(response, function);
-						this->writeModbus(response, 0); // TODO: Write IlC State
-						this->writeModbus(response, 0);
-						this->writeModbus(response, 0); // TODO: Write ILC Status
-						this->writeModbus(response, 0);
-						this->writeModbus(response, 0); // TODO: Write ILC Faults
-						this->writeModbusCRC(response);
-						break;
-					case 65: { // Change ILC Mode
-						++i; // Read Reserved Byte
-						uint16_t newMode = this->readModbus(data[i++]); // Read New Mode
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0); // Write Reserved Byte
-						this->writeModbus(response, newMode); // Write ILC State
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 66: { // Step Motor
-						int steps = data[i++]; // Read Steps
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, (uint8_t)this->outerLoopData->broadcastCounter); // Write ILC Status
-						// Number of steps issued / 4 + current encoder
-						// The encoder is also inverted after being received to match axis direction
-						// So we have to also invert the encoder here to counteract that
-						if (steps < 4 && steps > 0) {
-							steps = 4;
-						}
-						else if (steps > -4 && steps < 0) {
-							steps = -4;
-						}
-						int32_t encoder = -this->hardpointActuatorData->encoder[address - 1] - (steps / 4);
-						this->writeModbus(response, (encoder >> 24) & 0xFF);
-						this->writeModbus(response, (encoder >> 16) & 0xFF);
-						this->writeModbus(response, (encoder >> 8) & 0xFF);
-						this->writeModbus(response, encoder & 0xFF); // Write Encoder
-						uint8_t buffer[4];
-						float force = this->getRnd() * 8.0;
-						memcpy(buffer, &force, 4);
-						this->writeModbus(response, buffer[3]);
-						this->writeModbus(response, buffer[2]);
-						this->writeModbus(response, buffer[1]);
-						this->writeModbus(response, buffer[0]); // Write Measured Force
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 67: { // Force And Status
-//						int steps = this->appliedHardpointSteps->commandedSteps[address - 1];
-                                                int steps=0;
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, (uint8_t)this->outerLoopData->broadcastCounter); // Write ILC Status
-						// Number of steps issued / 4 + current encoder
-						// The encoder is also inverted after being received to match axis direction
-						// So we have to also invert the encoder here to counteract that
-						if (steps < 4 && steps > 0) {
-							steps = 4;
-						}
-						else if (steps > -4 && steps < 0) {
-							steps = -4;
-						}
-						int32_t encoder = -this->hardpointActuatorData->encoder[address - 1];
-						if (stepMotorBroadcast) {
-							encoder = encoder - (steps / 4);
-						}
-						this->writeModbus(response, (encoder >> 24) & 0xFF);
-						this->writeModbus(response, (encoder >> 16) & 0xFF);
-						this->writeModbus(response, (encoder >> 8) & 0xFF);
-						this->writeModbus(response, encoder & 0xFF); // Write Encoder
-						uint8_t buffer[4];
-						float force = this->getRnd() * 8.0;
-						memcpy(buffer, &force, 4);
-						this->writeModbus(response, buffer[3]);
-						this->writeModbus(response, buffer[2]);
-						this->writeModbus(response, buffer[1]);
-						this->writeModbus(response, buffer[0]); // Write Measured Force
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 80: { // ADC Scan Rate
-						uint16_t scanRate = this->readModbus(data[i++]);
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, scanRate); // Write ADC Scan Rate
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 81: // ADC Channel Offset and Sensitivity
-						++i; // Read ADC Channel
-						i += 4; // Read Offset
-						i += 4; // Read Sensitivity
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbusCRC(response);
-						break;
-					case 107: // Reset
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbusCRC(response);
-						break;
-					case 110: { // Read Calibration
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						for(int j = 0; j < 24; ++j) {
-							uint8_t buffer[4];
-							float value = 0.0;
-							memcpy(buffer, &value, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write Calibration Data
-						}
-						this->writeModbusCRC(response);
-						break;
-					}
-					default:
-						break;
-					}
-				}
-				else if (subnet == 5 && address >= 84 && address <= 89) {
-					switch(function) {
-					case 17: // Report Server Id
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 12); // Write Message Length
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, signal);
-						this->writeModbus(response, address); // Write ILC Unique Id
-						this->writeModbus(response, 0); // TODO: Write ILC Application Type
-						this->writeModbus(response, 0); // TODO: Write Network Node Type
-						this->writeModbus(response, 0); // TODO: Write ILC Selected Options
-						this->writeModbus(response, 0); // TODO: Write Network Node Options
-						this->writeModbus(response, 99); // TODO: Write Major Revision
-						this->writeModbus(response, 99); // TODO: Write Minor Revision
-						// TODO: Write Firmware Name
-						this->writeModbusCRC(response);
-						break;
-					case 18: // Report Server Status
-						this->writeModbus(response, address);
-						this->writeModbus(response, function);
-						this->writeModbus(response, 0); // TODO: Write IlC State
-						this->writeModbus(response, 0);
-						this->writeModbus(response, 0); // TODO: Write ILC Status
-						this->writeModbus(response, 0);
-						this->writeModbus(response, 0); // TODO: Write ILC Faults
-						this->writeModbusCRC(response);
-						break;
-					case 65: { // Change ILC Mode
-						++i; // Read Reserved Byte
-						uint16_t newMode = this->readModbus(data[i++]); // Read New Mode
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0); // Write Reserved Byte
-						this->writeModbus(response, newMode); // Write ILC State
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 107: // Reset
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbusCRC(response);
-						break;
-					case 119: { // Read DCA Pressure Values
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						for(int j = 0; j < 4; ++j) {
-							uint8_t buffer[4];
-							float value = 120.0;
-							memcpy(buffer, &value, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write DCA Pressure
-						}
-						this->writeModbusCRC(response);
-						break;
-					}
-					case 120: // Read DCA Id
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x01);
-						this->writeModbus(response, signal);
-						this->writeModbus(response, address); // Write DCA Unique Id
-						this->writeModbus(response, 0); // TODO: Write DCA Firmware Type
-						this->writeModbus(response, 99); // TODO: Write Major Revision
-						this->writeModbus(response, 99); // TODO: Write Minor Revision
-						this->writeModbusCRC(response);
-						break;
-					case 121: // Read DCA Status
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						this->writeModbus(response, 0x00);
-						this->writeModbus(response, 0x00); // TODO: Write DCA Status
-						this->writeModbusCRC(response);
-						break;
-					case 122: // Report LVDT
-						this->writeModbus(response, address); // Write Address
-						this->writeModbus(response, function); // Write Function
-						for(int j = 0; j < 2; ++j) {
-							uint8_t buffer[4];
-							float value = 0.0;
-							memcpy(buffer, &value, 4);
-							this->writeModbus(response, buffer[3]);
-							this->writeModbus(response, buffer[2]);
-							this->writeModbus(response, buffer[1]);
-							this->writeModbus(response, buffer[0]); // Write LVDT
-						}
-						this->writeModbusCRC(response);
-						break;
-					default:
-						break;
-					}
-				}
-				i += 2; // Read CRC
-				++i; // Read End of Frame
-				++i; // Read Wait for Rx or Delay
-			}
-			++i; // Read Write Trigger IRQ
-		}
-	}
-	return 0;
+    for (int i = 0; i < length;) {
+        uint16_t signal = data[i++];
+        uint16_t dataLength = 0;
+        uint16_t subnet = 0;
+        std::queue<uint16_t>* response = 0;
+        switch (signal) {
+            case FPGAAddresses::AccelerometerAx:
+            case FPGAAddresses::AccelerometerAz:
+            case FPGAAddresses::AccelerometerBy:
+            case FPGAAddresses::AccelerometerBz:
+            case FPGAAddresses::AccelerometerCx:
+            case FPGAAddresses::AccelerometerCz:
+            case FPGAAddresses::AccelerometerDy:
+            case FPGAAddresses::AccelerometerDz:
+                break;
+            case FPGAAddresses::ModbusSubnetATx:
+                subnet = 1;
+                response = &this->subnetAResponse;
+                dataLength = data[i++];
+                break;
+            case FPGAAddresses::ModbusSubnetBTx:
+                subnet = 2;
+                response = &this->subnetBResponse;
+                dataLength = data[i++];
+                break;
+            case FPGAAddresses::ModbusSubnetCTx:
+                subnet = 3;
+                response = &this->subnetCResponse;
+                dataLength = data[i++];
+                break;
+            case FPGAAddresses::ModbusSubnetDTx:
+                subnet = 4;
+                response = &this->subnetDResponse;
+                dataLength = data[i++];
+                break;
+            case FPGAAddresses::ModbusSubnetARx:
+            case FPGAAddresses::ModbusSubnetBRx:
+            case FPGAAddresses::ModbusSubnetCRx:
+            case FPGAAddresses::ModbusSubnetDRx:
+                break;
+            case FPGAAddresses::ModbusSubnetETx:
+                subnet = 5;
+                response = &this->subnetEResponse;
+                dataLength = data[i++];
+                break;
+            case FPGAAddresses::GyroTx: {
+                int size = data[i++];  // Read Tx Size
+                i += size;             // Read All Tx Data
+                break;
+            }
+            case FPGAAddresses::ModbusSubnetERx:
+            case FPGAAddresses::GyroRx:
+                break;
+            case FPGAAddresses::ILCPowerInterlockStatus:
+            case FPGAAddresses::FanCoilerHeaterInterlockStatus:
+            case FPGAAddresses::AirSupplyInterlockStatus:
+            case FPGAAddresses::CabinetDoorInterlockStatus:
+            case FPGAAddresses::TMAMotionStopInterlockStatus:
+            case FPGAAddresses::GISHeartbeatInterlockStatus:
+            case FPGAAddresses::AirSupplyValveOpen:
+            case FPGAAddresses::AirSupplyValveClosed:
+            case FPGAAddresses::MirrorCellLightsOn:
+            case FPGAAddresses::HeartbeatToSafetyController: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.DigitalOutputStates & 0xFE) | (state ? 0x01 : 0x00);
+                break;
+            }
+            case FPGAAddresses::AirSupplyValveControl: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.DigitalOutputStates & 0xEF) | (state ? 0x00 : 0x10);
+                this->supportFPGAData.DigitalInputStates =
+                        (this->supportFPGAData.DigitalInputStates & 0xFCFF) | (state ? 0x0200 : 0x0100);
+                break;
+            }
+            case FPGAAddresses::MirrorCellLightControl: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.DigitalOutputStates & 0xDF) | (state ? 0x20 : 0x00);
+                this->supportFPGAData.DigitalInputStates =
+                        (this->supportFPGAData.DigitalInputStates & 0xFBFF) | (state ? 0x0400 : 0x0000);
+                break;
+            }
+            case FPGAAddresses::DCAuxPowerNetworkAOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xFE) | (state ? 0x01 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCAuxPowerNetworkBOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xFD) | (state ? 0x02 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCAuxPowerNetworkCOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xFB) | (state ? 0x04 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCAuxPowerNetworkDOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xF7) | (state ? 0x08 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCPowerNetworkAOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xEF) | (state ? 0x10 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCPowerNetworkBOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xDF) | (state ? 0x20 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCPowerNetworkCOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0xBF) | (state ? 0x40 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::DCPowerNetworkDOn: {
+                int state = data[i++];
+                this->supportFPGAData.DigitalOutputStates =
+                        (this->supportFPGAData.PowerSupplyStates & 0x7F) | (state ? 0x80 : 0x00);
+                // TODO: Set Power Supply Currents
+                break;
+            }
+            case FPGAAddresses::Displacement:
+            case FPGAAddresses::Inclinometer:
+            case FPGAAddresses::ModbusSoftwareTrigger:
+            case FPGAAddresses::Telemetry:
+            case FPGAAddresses::HealthAndStatus:
+            case FPGAAddresses::Timestamp:
+                break;
+            default:
+                break;
+        }
+        if (response != 0) {
+            bool stepMotorBroadcast = false;
+            ++i;  // Read Software Trigger
+            // Response length is prepended at request
+            uint64_t rawTimestamp = Timestamp::toRaw(this->publisher->getTimestamp());
+            response->push((uint16_t)(rawTimestamp >> 48));
+            response->push((uint16_t)(rawTimestamp >> 32));
+            response->push((uint16_t)(rawTimestamp >> 16));
+            response->push((uint16_t)rawTimestamp);  // Write Global Timestamp
+            int endIndex = i - 1 + dataLength - 1;
+            MTM1M3_hardpointActuatorDataC* hardpointActuatorData =
+                    this->publisher->getHardpointActuatorData();
+            // The first -1 is for the software trigger
+            // The second -1 is for the trigger
+            while (i < endIndex) {
+                uint16_t address = this->readModbus(data[i++]);   // Read Address
+                uint16_t function = this->readModbus(data[i++]);  // Read Function Code
+                if (address == 248 && function == 66) {
+                    stepMotorBroadcast = true;
+                }
+                if (address == 248 || address == 249) {
+                    // This is a broadcast, no response, just read until 0xA000
+                    while ((data[i] & 0xF000) != 0x2000) {
+                        ++i;
+                    }
+                    i--;  // Shift to CRC for the remainder of the time
+                          // However broadcasts are followed by a timestamp
+                          // so only shift 1
+                } else if (address == 0 && function == 0) {
+                    // This is a special nop, read until 0xF000 != 0
+                    while (data[i] == 0) {
+                        ++i;
+                    }
+                    i -= 4;  // Shift to CRC for the rest of the parsing to work
+                } else if (subnet >= 1 && subnet <= 4) {
+                    int zIndex = -1;
+                    for (int j = 0; j < FA_COUNT; ++j) {
+                        if (this->forceActuatorApplicationSettings->Table[j].Subnet == subnet &&
+                            this->forceActuatorApplicationSettings->Table[j].Address == address) {
+                            zIndex = j;
+                            break;
+                        }
+                    }
+                    int pIndex = zIndex;
+                    int sIndex =
+                            this->forceActuatorApplicationSettings->ZIndexToSecondaryCylinderIndex[zIndex];
+                    switch (function) {
+                        case 17:                                    // Report Server Id
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 12);        // Write Message Length
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, signal);
+                            this->writeModbus(response, address);  // Write ILC Unique Id
+                            this->writeModbus(response, 0);        // TODO: Write ILC Application Type
+                            this->writeModbus(response, 0);        // TODO: Write Network Node Type
+                            this->writeModbus(response, 0);        // TODO: Write ILC Selected Options
+                            this->writeModbus(response, 0);        // TODO: Write Network Node Options
+                            this->writeModbus(response, 99);       // TODO: Write Major Revision
+                            this->writeModbus(response, 99);       // TODO: Write Minor Revision
+                            // TODO: Write Firmware Name
+                            this->writeModbusCRC(response);
+                            break;
+                        case 18:  // Report Server Status
+                            this->writeModbus(response, address);
+                            this->writeModbus(response, function);
+                            this->writeModbus(response, 0);  // TODO: Write IlC State
+                            this->writeModbus(response, 0);
+                            this->writeModbus(response, 0);  // TODO: Write ILC Status
+                            this->writeModbus(response, 0);
+                            this->writeModbus(response, 0);  // TODO: Write ILC Faults
+                            this->writeModbusCRC(response);
+                            break;
+                        case 65: {                                           // Change ILC Mode
+                            ++i;                                             // Read Reserved Byte
+                            uint16_t newMode = this->readModbus(data[i++]);  // Read New Mode
+                            this->writeModbus(response, address);            // Write Address
+                            this->writeModbus(response, function);           // Write Function
+                            this->writeModbus(response, 0);                  // Write Reserved Byte
+                            this->writeModbus(response, newMode);            // Write ILC State
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 73:                                    // Set Boost Valve DCA Gains
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            i += 4;                                 // Read Primary Cylinder DCA Gain
+                            i += 4;                                 // Read Secondary Cylinder DCA Gain
+                            this->writeModbusCRC(response);
+                            break;
+                        case 74: {                                  // Read Boost Valve DCA Gains
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            uint8_t buffer[4];
+                            float gain = 1.0;
+                            memcpy(buffer, &gain, 4);
+                            this->writeModbus(response, buffer[3]);
+                            this->writeModbus(response, buffer[2]);
+                            this->writeModbus(response, buffer[1]);
+                            this->writeModbus(response, buffer[0]);  // Write Primary Cylinder DCA Gain
+                            this->writeModbus(response, buffer[3]);
+                            this->writeModbus(response, buffer[2]);
+                            this->writeModbus(response, buffer[1]);
+                            this->writeModbus(response, buffer[0]);  // Write Secondary Cylinder DCA Gain
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 75: {  // Force Demand
+                            ++i;    // Read Slew Flag
+                            uint16_t word1 = this->readModbus(data[i++]);
+                            uint16_t word2 = this->readModbus(data[i++]);
+                            uint16_t word3 = this->readModbus(data[i++]);
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response,
+                                              (uint8_t)this->publisher->getOuterLoopData()
+                                                      ->broadcastCounter);  // Write ILC Status
+                            uint8_t buffer[4];
+                            float force = (((float)((word1 << 16) | (word2 << 8) | word3)) / 1000.0) +
+                                          (this->getRnd() * 0.5);
+                            memcpy(buffer, &force, 4);
+                            this->writeModbus(response, buffer[3]);
+                            this->writeModbus(response, buffer[2]);
+                            this->writeModbus(response, buffer[1]);
+                            this->writeModbus(response, buffer[0]);  // Write Primary Cylinder Force
+                            if (address > 16) {
+                                word1 = this->readModbus(data[i++]);
+                                word2 = this->readModbus(data[i++]);
+                                word3 = this->readModbus(data[i++]);
+                                force = (((float)((word1 << 16) | (word2 << 8) | word3)) / 1000.0) +
+                                        (this->getRnd() * 0.5);
+                                memcpy(buffer, &force, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write Secondary Cylinder Force
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 76: {                                  // Force And Status
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response,
+                                              (uint8_t)this->publisher->getOuterLoopData()
+                                                      ->broadcastCounter);  // Write ILC Status
+                            uint8_t buffer[4];
+                            float force = (((float)this->publisher->getEventAppliedCylinderForces()
+                                                    ->primaryCylinderForces[pIndex]) /
+                                           1000.0) +
+                                          (this->getRnd() * 0.5);  // Update to Primary Cylinder Force
+                            memcpy(buffer, &force, 4);
+                            this->writeModbus(response, buffer[3]);
+                            this->writeModbus(response, buffer[2]);
+                            this->writeModbus(response, buffer[1]);
+                            this->writeModbus(response, buffer[0]);  // Write Primary Cylinder Force
+                            if (address > 16) {
+                                force = (((float)this->publisher->getEventAppliedCylinderForces()
+                                                  ->secondaryCylinderForces[sIndex]) /
+                                         1000.0) +
+                                        (this->getRnd() * 0.5);  // Update to Secondary Cylinder Force
+                                memcpy(buffer, &force, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write Secondary Cylinder Force
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 80: {  // ADC Scan Rate
+                            uint16_t scanRate = this->readModbus(data[i++]);
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, scanRate);  // Write ADC Scan Rate
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 81:                                    // ADC Channel Offset and Sensitivity
+                            ++i;                                    // Read ADC Channel
+                            i += 4;                                 // Read Offset
+                            i += 4;                                 // Read Sensitivity
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbusCRC(response);
+                            break;
+                        case 107:                                   // Reset
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbusCRC(response);
+                            break;
+                        case 110: {                                 // Read Calibration
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            for (int j = 0; j < 24; ++j) {
+                                uint8_t buffer[4];
+                                float value = 0.0;
+                                memcpy(buffer, &value, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write Calibration Data
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 119: {                                 // Read DCA Pressure Values
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            for (int j = 0; j < 4; ++j) {
+                                uint8_t buffer[4];
+                                float value = 120.0;
+                                memcpy(buffer, &value, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write DCA Pressure
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 120:                                   // Read DCA Id
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x01);
+                            this->writeModbus(response, signal);
+                            this->writeModbus(response, address);  // Write DCA Unique Id
+                            this->writeModbus(response, 0);        // TODO: Write DCA Firmware Type
+                            this->writeModbus(response, 99);       // TODO: Write Major Revision
+                            this->writeModbus(response, 99);       // TODO: Write Minor Revision
+                            this->writeModbusCRC(response);
+                            break;
+                        case 121:                                   // Read DCA Status
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);  // TODO: Write DCA Status
+                            this->writeModbusCRC(response);
+                            break;
+                        default:
+                            break;
+                    }
+                } else if (subnet == 5 && address >= 1 && address <= 6) {
+                    switch (function) {
+                        case 17:                                    // Report Server Id
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 12);        // Write Message Length
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, signal);
+                            this->writeModbus(response, address);  // Write ILC Unique Id
+                            this->writeModbus(response, 0);        // TODO: Write ILC Application Type
+                            this->writeModbus(response, 0);        // TODO: Write Network Node Type
+                            this->writeModbus(response, 0);        // TODO: Write ILC Selected Options
+                            this->writeModbus(response, 0);        // TODO: Write Network Node Options
+                            this->writeModbus(response, 99);       // TODO: Write Major Revision
+                            this->writeModbus(response, 99);       // TODO: Write Minor Revision
+                            // TODO: Write Firmware Name
+                            this->writeModbusCRC(response);
+                            break;
+                        case 18:  // Report Server Status
+                            this->writeModbus(response, address);
+                            this->writeModbus(response, function);
+                            this->writeModbus(response, 0);  // TODO: Write IlC State
+                            this->writeModbus(response, 0);
+                            this->writeModbus(response, 0);  // TODO: Write ILC Status
+                            this->writeModbus(response, 0);
+                            this->writeModbus(response, 0);  // TODO: Write ILC Faults
+                            this->writeModbusCRC(response);
+                            break;
+                        case 65: {                                           // Change ILC Mode
+                            ++i;                                             // Read Reserved Byte
+                            uint16_t newMode = this->readModbus(data[i++]);  // Read New Mode
+                            this->writeModbus(response, address);            // Write Address
+                            this->writeModbus(response, function);           // Write Function
+                            this->writeModbus(response, 0);                  // Write Reserved Byte
+                            this->writeModbus(response, newMode);            // Write ILC State
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 66: {                                  // Step Motor
+                            int steps = data[i++];                  // Read Steps
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response,
+                                              (uint8_t)this->publisher->getOuterLoopData()
+                                                      ->broadcastCounter);  // Write ILC Status
+                            // Number of steps issued / 4 + current encoder
+                            // The encoder is also inverted after being received to match axis direction
+                            // So we have to also invert the encoder here to counteract that
+                            if (steps < 4 && steps > 0) {
+                                steps = 4;
+                            } else if (steps > -4 && steps < 0) {
+                                steps = -4;
+                            }
+                            int32_t encoder = -hardpointActuatorData->encoder[address - 1] - (steps / 4);
+                            this->writeModbus(response, (encoder >> 24) & 0xFF);
+                            this->writeModbus(response, (encoder >> 16) & 0xFF);
+                            this->writeModbus(response, (encoder >> 8) & 0xFF);
+                            this->writeModbus(response, encoder & 0xFF);  // Write Encoder
+                            uint8_t buffer[4];
+                            float force = this->getRnd() * 8.0;
+                            memcpy(buffer, &force, 4);
+                            this->writeModbus(response, buffer[3]);
+                            this->writeModbus(response, buffer[2]);
+                            this->writeModbus(response, buffer[1]);
+                            this->writeModbus(response, buffer[0]);  // Write Measured Force
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 67: {  // Force And Status
+                                    //						int steps =
+                                    // this->publisher->getEventAppliedHardpointSteps()->commandedSteps[address
+                                    // -  1];
+                            int steps = 0;
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response,
+                                              (uint8_t)this->publisher->getOuterLoopData()
+                                                      ->broadcastCounter);  // Write ILC Status
+                            // Number of steps issued / 4 + current encoder
+                            // The encoder is also inverted after being received to match axis direction
+                            // So we have to also invert the encoder here to counteract that
+                            if (steps < 4 && steps > 0) {
+                                steps = 4;
+                            } else if (steps > -4 && steps < 0) {
+                                steps = -4;
+                            }
+                            int32_t encoder = -hardpointActuatorData->encoder[address - 1];
+                            if (stepMotorBroadcast) {
+                                encoder = encoder - (steps / 4);
+                            }
+                            this->writeModbus(response, (encoder >> 24) & 0xFF);
+                            this->writeModbus(response, (encoder >> 16) & 0xFF);
+                            this->writeModbus(response, (encoder >> 8) & 0xFF);
+                            this->writeModbus(response, encoder & 0xFF);  // Write Encoder
+                            uint8_t buffer[4];
+                            float force = this->getRnd() * 8.0;
+                            memcpy(buffer, &force, 4);
+                            this->writeModbus(response, buffer[3]);
+                            this->writeModbus(response, buffer[2]);
+                            this->writeModbus(response, buffer[1]);
+                            this->writeModbus(response, buffer[0]);  // Write Measured Force
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 80: {  // ADC Scan Rate
+                            uint16_t scanRate = this->readModbus(data[i++]);
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, scanRate);  // Write ADC Scan Rate
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 81:                                    // ADC Channel Offset and Sensitivity
+                            ++i;                                    // Read ADC Channel
+                            i += 4;                                 // Read Offset
+                            i += 4;                                 // Read Sensitivity
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbusCRC(response);
+                            break;
+                        case 107:                                   // Reset
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbusCRC(response);
+                            break;
+                        case 110: {                                 // Read Calibration
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            for (int j = 0; j < 24; ++j) {
+                                uint8_t buffer[4];
+                                float value = 0.0;
+                                memcpy(buffer, &value, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write Calibration Data
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                } else if (subnet == 5 && address >= 84 && address <= 89) {
+                    switch (function) {
+                        case 17:                                    // Report Server Id
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 12);        // Write Message Length
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, signal);
+                            this->writeModbus(response, address);  // Write ILC Unique Id
+                            this->writeModbus(response, 0);        // TODO: Write ILC Application Type
+                            this->writeModbus(response, 0);        // TODO: Write Network Node Type
+                            this->writeModbus(response, 0);        // TODO: Write ILC Selected Options
+                            this->writeModbus(response, 0);        // TODO: Write Network Node Options
+                            this->writeModbus(response, 99);       // TODO: Write Major Revision
+                            this->writeModbus(response, 99);       // TODO: Write Minor Revision
+                            // TODO: Write Firmware Name
+                            this->writeModbusCRC(response);
+                            break;
+                        case 18:  // Report Server Status
+                            this->writeModbus(response, address);
+                            this->writeModbus(response, function);
+                            this->writeModbus(response, 0);  // TODO: Write IlC State
+                            this->writeModbus(response, 0);
+                            this->writeModbus(response, 0);  // TODO: Write ILC Status
+                            this->writeModbus(response, 0);
+                            this->writeModbus(response, 0);  // TODO: Write ILC Faults
+                            this->writeModbusCRC(response);
+                            break;
+                        case 65: {                                           // Change ILC Mode
+                            ++i;                                             // Read Reserved Byte
+                            uint16_t newMode = this->readModbus(data[i++]);  // Read New Mode
+                            this->writeModbus(response, address);            // Write Address
+                            this->writeModbus(response, function);           // Write Function
+                            this->writeModbus(response, 0);                  // Write Reserved Byte
+                            this->writeModbus(response, newMode);            // Write ILC State
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 107:                                   // Reset
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbusCRC(response);
+                            break;
+                        case 119: {                                 // Read DCA Pressure Values
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            for (int j = 0; j < 4; ++j) {
+                                uint8_t buffer[4];
+                                float value = 120.0;
+                                memcpy(buffer, &value, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write DCA Pressure
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        }
+                        case 120:                                   // Read DCA Id
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x01);
+                            this->writeModbus(response, signal);
+                            this->writeModbus(response, address);  // Write DCA Unique Id
+                            this->writeModbus(response, 0);        // TODO: Write DCA Firmware Type
+                            this->writeModbus(response, 99);       // TODO: Write Major Revision
+                            this->writeModbus(response, 99);       // TODO: Write Minor Revision
+                            this->writeModbusCRC(response);
+                            break;
+                        case 121:                                   // Read DCA Status
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            this->writeModbus(response, 0x00);
+                            this->writeModbus(response, 0x00);  // TODO: Write DCA Status
+                            this->writeModbusCRC(response);
+                            break;
+                        case 122:                                   // Report LVDT
+                            this->writeModbus(response, address);   // Write Address
+                            this->writeModbus(response, function);  // Write Function
+                            for (int j = 0; j < 2; ++j) {
+                                uint8_t buffer[4];
+                                float value = 0.0;
+                                memcpy(buffer, &value, 4);
+                                this->writeModbus(response, buffer[3]);
+                                this->writeModbus(response, buffer[2]);
+                                this->writeModbus(response, buffer[1]);
+                                this->writeModbus(response, buffer[0]);  // Write LVDT
+                            }
+                            this->writeModbusCRC(response);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                i += 2;  // Read CRC
+                ++i;     // Read End of Frame
+                ++i;     // Read Wait for Rx or Delay
+            }
+            ++i;  // Read Write Trigger IRQ
+        }
+    }
+    return 0;
 }
 
 void SimulatedFPGA::writeModbus(std::queue<uint16_t>* response, uint16_t data) {
-	this->crcVector.push(data);
-	response->push((data << 1) | 0x9000);
+    this->crcVector.push(data);
+    response->push((data << 1) | 0x9000);
 }
 
 void SimulatedFPGA::writeModbusCRC(std::queue<uint16_t>* response) {
-	uint16_t buffer[256];
-	int i = 0;
-	while(!this->crcVector.empty()) {
-		buffer[i] = this->crcVector.front();
-		i++;
-		this->crcVector.pop();
-
-	}
-	uint16_t crc = CRC::modbus(buffer, 0, i);
-	response->push((((crc >> 0) & 0xFF) << 1) | 0x9000);
-	response->push((((crc >> 8) & 0xFF) << 1) | 0x9000); // Write CRC
-	for (int i = 0; i < 8; ++i) {
-		response->push(0xB000); // Write Timestamp
-	}
-	response->push(0xA000); // Write End of Frame
+    uint16_t buffer[256];
+    int i = 0;
+    while (!this->crcVector.empty()) {
+        buffer[i] = this->crcVector.front();
+        i++;
+        this->crcVector.pop();
+    }
+    uint16_t crc = CRC::modbus(buffer, 0, i);
+    response->push((((crc >> 0) & 0xFF) << 1) | 0x9000);
+    response->push((((crc >> 8) & 0xFF) << 1) | 0x9000);  // Write CRC
+    for (int i = 0; i < 8; ++i) {
+        response->push(0xB000);  // Write Timestamp
+    }
+    response->push(0xA000);  // Write End of Frame
 }
 
-uint16_t SimulatedFPGA::readModbus(uint16_t data) {
-	return (data >> 1) & 0xFF;
-}
+uint16_t SimulatedFPGA::readModbus(uint16_t data) { return (data >> 1) & 0xFF; }
 
-int32_t SimulatedFPGA::writeCommandFIFO(uint16_t data, int32_t timeoutInMs) {
-	return 0;
-}
+int32_t SimulatedFPGA::writeCommandFIFO(uint16_t data, int32_t timeoutInMs) { return 0; }
 
 int32_t SimulatedFPGA::writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) {
-	int signal = data[0];
-	std::queue<uint16_t>* modbusResponse = 0;
-	switch(signal) {
-	case FPGAAddresses::AccelerometerAx:
-	case FPGAAddresses::AccelerometerAz:
-	case FPGAAddresses::AccelerometerBy:
-	case FPGAAddresses::AccelerometerBz:
-	case FPGAAddresses::AccelerometerCx:
-	case FPGAAddresses::AccelerometerCz:
-	case FPGAAddresses::AccelerometerDy:
-	case FPGAAddresses::AccelerometerDz:
-	case FPGAAddresses::ModbusSubnetATx:
-	case FPGAAddresses::ModbusSubnetBTx:
-	case FPGAAddresses::ModbusSubnetCTx:
-	case FPGAAddresses::ModbusSubnetDTx:
-	case FPGAAddresses::ModbusSubnetARx:
-		modbusResponse = &this->subnetAResponse;
-		break;
-	case FPGAAddresses::ModbusSubnetBRx:
-		modbusResponse = &this->subnetBResponse;
-		break;
-	case FPGAAddresses::ModbusSubnetCRx:
-		modbusResponse = &this->subnetCResponse;
-		break;
-	case FPGAAddresses::ModbusSubnetDRx:
-		modbusResponse = &this->subnetDResponse;
-		break;
-	case FPGAAddresses::ModbusSubnetETx:
-	case FPGAAddresses::GyroTx:
-	case FPGAAddresses::ModbusSubnetERx:
-		modbusResponse = &this->subnetEResponse;
-		break;
-	case FPGAAddresses::GyroRx:
-	case FPGAAddresses::ILCPowerInterlockStatus:
-	case FPGAAddresses::FanCoilerHeaterInterlockStatus:
-	case FPGAAddresses::AirSupplyInterlockStatus:
-	case FPGAAddresses::CabinetDoorInterlockStatus:
-	case FPGAAddresses::TMAMotionStopInterlockStatus:
-	case FPGAAddresses::GISHeartbeatInterlockStatus:
-	case FPGAAddresses::AirSupplyValveOpen:
-	case FPGAAddresses::AirSupplyValveClosed:
-	case FPGAAddresses::MirrorCellLightsOn:
-	case FPGAAddresses::HeartbeatToSafetyController:
-	case FPGAAddresses::AirSupplyValveControl:
-	case FPGAAddresses::MirrorCellLightControl:
-	case FPGAAddresses::DCAuxPowerNetworkAOn:
-	case FPGAAddresses::DCAuxPowerNetworkBOn:
-	case FPGAAddresses::DCAuxPowerNetworkCOn:
-	case FPGAAddresses::DCAuxPowerNetworkDOn:
-	case FPGAAddresses::DCPowerNetworkAOn:
-	case FPGAAddresses::DCPowerNetworkBOn:
-	case FPGAAddresses::DCPowerNetworkCOn:
-	case FPGAAddresses::DCPowerNetworkDOn:
-	case FPGAAddresses::Displacement:
-	case FPGAAddresses::Inclinometer:
-	case FPGAAddresses::ModbusSoftwareTrigger:
-	case FPGAAddresses::Telemetry:
-	case FPGAAddresses::HealthAndStatus:
-	case FPGAAddresses::Timestamp:
-		break;
-	default: break;
-	}
-	if (modbusResponse != 0) {
-		this->u16Response.push((uint16_t)modbusResponse->size());
-		while (modbusResponse->size() > 0) {
-			this->u16Response.push(modbusResponse->front());
-			modbusResponse->pop();
-		}
-	}
-	return 0;
+    int signal = data[0];
+    std::queue<uint16_t>* modbusResponse = 0;
+    switch (signal) {
+        case FPGAAddresses::AccelerometerAx:
+        case FPGAAddresses::AccelerometerAz:
+        case FPGAAddresses::AccelerometerBy:
+        case FPGAAddresses::AccelerometerBz:
+        case FPGAAddresses::AccelerometerCx:
+        case FPGAAddresses::AccelerometerCz:
+        case FPGAAddresses::AccelerometerDy:
+        case FPGAAddresses::AccelerometerDz:
+        case FPGAAddresses::ModbusSubnetATx:
+        case FPGAAddresses::ModbusSubnetBTx:
+        case FPGAAddresses::ModbusSubnetCTx:
+        case FPGAAddresses::ModbusSubnetDTx:
+        case FPGAAddresses::ModbusSubnetARx:
+            modbusResponse = &this->subnetAResponse;
+            break;
+        case FPGAAddresses::ModbusSubnetBRx:
+            modbusResponse = &this->subnetBResponse;
+            break;
+        case FPGAAddresses::ModbusSubnetCRx:
+            modbusResponse = &this->subnetCResponse;
+            break;
+        case FPGAAddresses::ModbusSubnetDRx:
+            modbusResponse = &this->subnetDResponse;
+            break;
+        case FPGAAddresses::ModbusSubnetETx:
+        case FPGAAddresses::GyroTx:
+        case FPGAAddresses::ModbusSubnetERx:
+            modbusResponse = &this->subnetEResponse;
+            break;
+        case FPGAAddresses::GyroRx:
+        case FPGAAddresses::ILCPowerInterlockStatus:
+        case FPGAAddresses::FanCoilerHeaterInterlockStatus:
+        case FPGAAddresses::AirSupplyInterlockStatus:
+        case FPGAAddresses::CabinetDoorInterlockStatus:
+        case FPGAAddresses::TMAMotionStopInterlockStatus:
+        case FPGAAddresses::GISHeartbeatInterlockStatus:
+        case FPGAAddresses::AirSupplyValveOpen:
+        case FPGAAddresses::AirSupplyValveClosed:
+        case FPGAAddresses::MirrorCellLightsOn:
+        case FPGAAddresses::HeartbeatToSafetyController:
+        case FPGAAddresses::AirSupplyValveControl:
+        case FPGAAddresses::MirrorCellLightControl:
+        case FPGAAddresses::DCAuxPowerNetworkAOn:
+        case FPGAAddresses::DCAuxPowerNetworkBOn:
+        case FPGAAddresses::DCAuxPowerNetworkCOn:
+        case FPGAAddresses::DCAuxPowerNetworkDOn:
+        case FPGAAddresses::DCPowerNetworkAOn:
+        case FPGAAddresses::DCPowerNetworkBOn:
+        case FPGAAddresses::DCPowerNetworkCOn:
+        case FPGAAddresses::DCPowerNetworkDOn:
+        case FPGAAddresses::Displacement:
+        case FPGAAddresses::Inclinometer:
+        case FPGAAddresses::ModbusSoftwareTrigger:
+        case FPGAAddresses::Telemetry:
+        case FPGAAddresses::HealthAndStatus:
+        case FPGAAddresses::Timestamp:
+            break;
+        default:
+            break;
+    }
+    if (modbusResponse != 0) {
+        this->u16Response.push((uint16_t)modbusResponse->size());
+        while (modbusResponse->size() > 0) {
+            this->u16Response.push(modbusResponse->front());
+            modbusResponse->pop();
+        }
+    }
+    return 0;
 }
 
 int32_t SimulatedFPGA::writeRequestFIFO(uint16_t data, int32_t timeoutInMs) {
-	uint16_t newData[1];
-	newData[0] = data;
-	return this->writeRequestFIFO(newData, 1, timeoutInMs);
+    uint16_t newData[1];
+    newData[0] = data;
+    return this->writeRequestFIFO(newData, 1, timeoutInMs);
 }
 
-int32_t SimulatedFPGA::writeTimestampFIFO(uint64_t timestamp) {
-	return 0;
-}
+int32_t SimulatedFPGA::writeTimestampFIFO(uint64_t timestamp) { return 0; }
 
-int32_t SimulatedFPGA::readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs) {
-	return 0;
-}
+int32_t SimulatedFPGA::readU8ResponseFIFO(uint8_t* data, int32_t length, int32_t timeoutInMs) { return 0; }
 
 int32_t SimulatedFPGA::readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeoutInMs) {
-	for(int i = 0; i < length; ++i) {
-		data[i] = this->u16Response.front();
-		this->u16Response.pop();
-	}
-	return 0;
+    for (int i = 0; i < length; ++i) {
+        data[i] = this->u16Response.front();
+        this->u16Response.pop();
+    }
+    return 0;
+}
+
+float SimulatedFPGA::getRnd() {
+    ++this->rndIndex;
+    if (this->rndIndex > RND_CNT) {
+        this->rndIndex = 0;
+    }
+    return this->rnd[rndIndex];
 }
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/FirmwareUpdate/FirmwareUpdate.h
+++ b/Controller/src/LSST/M1M3/SS/FirmwareUpdate/FirmwareUpdate.h
@@ -16,7 +16,6 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-class FPGA;
 class ModbusBuffer;
 class ILCSubnetData;
 
@@ -52,12 +51,11 @@ private:
 	std::vector<char> appData;
 	std::vector<IntelHexLine> hexData;
 	ILCApplicationStats appStats;
-	FPGA* fpga;
 	ILCSubnetData* subnetData;
 	int desiredState;
 
 public:
-	FirmwareUpdate(FPGA* fpga, ILCSubnetData* subnetData);
+	FirmwareUpdate(ILCSubnetData* subnetData);
 
 	bool Program(int actuatorId, std::string filePath);
 

--- a/Controller/src/LSST/M1M3/SS/ForceController/ForceController.cpp
+++ b/Controller/src/LSST/M1M3/SS/ForceController/ForceController.cpp
@@ -215,7 +215,7 @@ void ForceController::updateAppliedForces() {
 	}
 	if (this->elevationForceComponent.isEnabled() || this->elevationForceComponent.isDisabling()) {
 		if (this->elevationForceComponent.isEnabled()) {
-			double elevationAngle = this->forceActuatorSettings->UseInclinometer ? this->inclinometerData->inclinometerAngle : this->tmaElevationData.Elevation_Angle_Actual;
+			double elevationAngle = this->forceActuatorSettings->UseInclinometer ? this->inclinometerData->inclinometerAngle : this->tmaElevationData.position;
 			// Convert elevation angle to zenith angle (used by matrix)
 			elevationAngle = 90.0 - elevationAngle;
 			this->elevationForceComponent.applyElevationForcesByElevationAngle(elevationAngle);

--- a/Controller/src/LSST/M1M3/SS/Gyro/Gyro.h
+++ b/Controller/src/LSST/M1M3/SS/Gyro/Gyro.h
@@ -1,10 +1,3 @@
-/*
- * Gyro.h
- *
- *  Created on: Jan 4, 2018
- *      Author: ccontaxis
- */
-
 #ifndef GYRO_H_
 #define GYRO_H_
 
@@ -19,7 +12,6 @@ namespace M1M3 {
 namespace SS {
 
 class GyroSettings;
-class FPGA;
 struct SupportFPGAData;
 class M1M3SSPublisher;
 
@@ -29,8 +21,6 @@ class M1M3SSPublisher;
 class Gyro {
 private:
 	GyroSettings* gyroSettings;
-	FPGA* fpga;
-	SupportFPGAData* fpgaData;
 	M1M3SSPublisher* publisher;
 
 	MTM1M3_gyroDataC* gyroData;
@@ -46,10 +36,9 @@ public:
 	/*!
 	 * Instantiates the gyro sensor.
 	 * @param[in] gyroSettings The gyro settings.
-	 * @param[in] fpga The fpga.
 	 * @param[in] publisher The publisher.
 	 */
-	Gyro(GyroSettings* gyroSettings, FPGA* fpga, M1M3SSPublisher* publisher);
+	Gyro(GyroSettings* gyroSettings, M1M3SSPublisher* publisher);
 
 	/*!
 	 * Executes a built in test.

--- a/Controller/src/LSST/M1M3/SS/ILC/ILC.h
+++ b/Controller/src/LSST/M1M3/SS/ILC/ILC.h
@@ -36,7 +36,6 @@ namespace M1M3 {
 namespace SS {
 
 class M1M3SSPublisher;
-class FPGA;
 class IBusList;
 class ILCApplicationSettings;
 class ForceActuatorApplicationSettings;
@@ -53,7 +52,6 @@ class SafetyController;
 class ILC {
 private:
 	M1M3SSPublisher* publisher;
-	FPGA* fpga;
 	SafetyController* safetyController;
 	ILCSubnetData subnetData;
 	ILCMessageFactory ilcMessageFactory;
@@ -96,7 +94,7 @@ private:
 	int32_t controlListToggle;
 
 public:
-	ILC(M1M3SSPublisher* publisher, FPGA* fpga, PositionController* positionController, ILCApplicationSettings* ilcApplicationSettings, ForceActuatorApplicationSettings* forceActuatorApplicationSettings, ForceActuatorSettings* forceActuatorSettings, HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings, HardpointActuatorSettings* hardpointActuatorSettings, HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings, SafetyController* safetyController);
+	ILC(M1M3SSPublisher* publisher, PositionController* positionController, ILCApplicationSettings* ilcApplicationSettings, ForceActuatorApplicationSettings* forceActuatorApplicationSettings, ForceActuatorSettings* forceActuatorSettings, HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings, HardpointActuatorSettings* hardpointActuatorSettings, HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings, SafetyController* safetyController);
 	virtual ~ILC();
 
 	void programILC(int32_t actuatorId, std::string filePath);

--- a/Controller/src/LSST/M1M3/SS/Model/Model.cpp
+++ b/Controller/src/LSST/M1M3/SS/Model/Model.cpp
@@ -15,7 +15,8 @@
 #include <ILCApplicationSettings.h>
 #include <U16ArrayUtilities.h>
 #include <iostream>
-#include <FPGA.h>
+
+#include <IFPGA.h>
 #include <FPGAAddresses.h>
 #include <ForceController.h>
 #include <RecommendedApplicationSettings.h>
@@ -38,279 +39,294 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-Model::Model(SettingReader* settingReader, M1M3SSPublisher* publisher, FPGA* fpga, ExpansionFPGA* expansionFPGA, DigitalInputOutput* digitalInputOutput) {
-	Log.Debug("Model: Model()");
-	this->settingReader = settingReader;
-	this->publisher = publisher;
-	this->fpga = fpga;
-	this->expansionFPGA = expansionFPGA;
-	this->safetyController = 0;
-	this->displacement = 0;
-	this->inclinometer = 0;
-	this->ilc = 0;
-	this->forceController = 0;
-	this->positionController = 0;
-	this->digitalInputOutput = digitalInputOutput;
-	this->accelerometer = 0;
-	this->powerController = 0;
-	this->automaticOperationsController = 0;
-	this->gyro = 0;
-	this->cachedTimestamp = 0;
-	pthread_mutex_init(&this->mutex, NULL);
-	pthread_mutex_lock(&this->mutex);
+Model::Model(SettingReader* settingReader, M1M3SSPublisher* publisher,
+             DigitalInputOutput* digitalInputOutput) {
+    Log.Debug("Model: Model()");
+    this->settingReader = settingReader;
+    this->publisher = publisher;
+    this->safetyController = 0;
+    this->displacement = 0;
+    this->inclinometer = 0;
+    this->ilc = 0;
+    this->forceController = 0;
+    this->positionController = 0;
+    this->digitalInputOutput = digitalInputOutput;
+    this->accelerometer = 0;
+    this->powerController = 0;
+    this->automaticOperationsController = 0;
+    this->gyro = 0;
+    this->cachedTimestamp = 0;
+    pthread_mutex_init(&this->mutex, NULL);
+    pthread_mutex_lock(&this->mutex);
 }
 
 Model::~Model() {
-	pthread_mutex_unlock(&this->mutex);
-	pthread_mutex_destroy(&this->mutex);
+    pthread_mutex_unlock(&this->mutex);
+    pthread_mutex_destroy(&this->mutex);
 
-	if (this->safetyController) {
-		delete this->safetyController;
-	}
-	if (this->displacement) {
-		delete this->displacement;
-	}
-	if (this->inclinometer) {
-		delete this->inclinometer;
-	}
-	if (this->ilc) {
-		delete this->ilc;
-	}
-	if (this->forceController) {
-		delete this->forceController;
-	}
-	if (this->positionController) {
-		delete this->positionController;
-	}
-	if (this->accelerometer) {
-		delete this->accelerometer;
-	}
-	if (this->powerController) {
-		delete this->powerController;
-	}
-	if (this->automaticOperationsController) {
-		delete this->automaticOperationsController;
-	}
-	if (this->gyro) {
-		delete this->gyro;
-	}
+    if (this->safetyController) {
+        delete this->safetyController;
+    }
+    if (this->displacement) {
+        delete this->displacement;
+    }
+    if (this->inclinometer) {
+        delete this->inclinometer;
+    }
+    if (this->ilc) {
+        delete this->ilc;
+    }
+    if (this->forceController) {
+        delete this->forceController;
+    }
+    if (this->positionController) {
+        delete this->positionController;
+    }
+    if (this->accelerometer) {
+        delete this->accelerometer;
+    }
+    if (this->powerController) {
+        delete this->powerController;
+    }
+    if (this->automaticOperationsController) {
+        delete this->automaticOperationsController;
+    }
+    if (this->gyro) {
+        delete this->gyro;
+    }
 }
 
 void Model::loadSettings(std::string settingsToApply) {
-	Log.Info("Model: loadSettings(%s)", settingsToApply.c_str());
-	this->settingReader->configure(settingsToApply);
+    Log.Info("Model: loadSettings(%s)", settingsToApply.c_str());
+    this->settingReader->configure(settingsToApply);
 
-	this->publisher->getOuterLoopData()->slewFlag = false;
+    this->publisher->getOuterLoopData()->slewFlag = false;
 
-	Log.Info("Model: Loading ILC application settings");
-	ILCApplicationSettings* ilcApplicationSettings = this->settingReader->loadILCApplicationSettings();
-	Log.Info("Model: Loading force actuator application settings");
-	ForceActuatorApplicationSettings* forceActuatorApplicationSettings = this->settingReader->loadForceActuatorApplicationSettings();
-	Log.Info("Model: Loading force actuator settings");
-	ForceActuatorSettings* forceActuatorSettings = this->settingReader->loadForceActuatorSettings();
-	Log.Info("Model: Loading hardpoint actuator application settings");
-	HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings = this->settingReader->loadHardpointActuatorApplicationSettings();
-	Log.Info("Model: Loading hardpoint actuator settings");
-	HardpointActuatorSettings* hardpointActuatorSettings = this->settingReader->loadHardpointActuatorSettings();
-	Log.Info("Model: Loading safety controller settings");
-	SafetyControllerSettings* safetyControllerSettings = this->settingReader->loadSafetyControllerSettings();
-	Log.Info("Model: Loading position controller settings");
-	PositionControllerSettings* positionControllerSettings = this->settingReader->loadPositionControllerSettings();
-	Log.Info("Model: Loading accelerometer settings");
-	AccelerometerSettings* accelerometerSettings = this->settingReader->loadAccelerometerSettings();
-	Log.Info("Model: Loading displacement settings");
-	DisplacementSensorSettings* displacementSensorSettings = this->settingReader->loadDisplacementSensorSettings();
-	Log.Info("Model: Loading hardpoint monitor application settings");
-	HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings = this->settingReader->loadHardpointMonitorApplicationSettings();
-	Log.Info("Model: Loading gyro settings");
-	GyroSettings* gyroSettings = this->settingReader->loadGyroSettings();
-	Log.Info("Model: Loading PID settings");
-	PIDSettings* pidSettings = this->settingReader->loadPIDSettings();
-	Log.Info("Model: Loading inclinometer settings");
-	InclinometerSettings* inclinometerSettings = this->settingReader->loadInclinometerSettings();
+    Log.Info("Model: Loading ILC application settings");
+    ILCApplicationSettings* ilcApplicationSettings = this->settingReader->loadILCApplicationSettings();
+    Log.Info("Model: Loading force actuator application settings");
+    ForceActuatorApplicationSettings* forceActuatorApplicationSettings =
+            this->settingReader->loadForceActuatorApplicationSettings();
+    Log.Info("Model: Loading force actuator settings");
+    ForceActuatorSettings* forceActuatorSettings = this->settingReader->loadForceActuatorSettings();
+    Log.Info("Model: Loading hardpoint actuator application settings");
+    HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings =
+            this->settingReader->loadHardpointActuatorApplicationSettings();
+    Log.Info("Model: Loading hardpoint actuator settings");
+    HardpointActuatorSettings* hardpointActuatorSettings =
+            this->settingReader->loadHardpointActuatorSettings();
+    Log.Info("Model: Loading safety controller settings");
+    SafetyControllerSettings* safetyControllerSettings = this->settingReader->loadSafetyControllerSettings();
+    Log.Info("Model: Loading position controller settings");
+    PositionControllerSettings* positionControllerSettings =
+            this->settingReader->loadPositionControllerSettings();
+    Log.Info("Model: Loading accelerometer settings");
+    AccelerometerSettings* accelerometerSettings = this->settingReader->loadAccelerometerSettings();
+    Log.Info("Model: Loading displacement settings");
+    DisplacementSensorSettings* displacementSensorSettings =
+            this->settingReader->loadDisplacementSensorSettings();
+    Log.Info("Model: Loading hardpoint monitor application settings");
+    HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings =
+            this->settingReader->loadHardpointMonitorApplicationSettings();
+    Log.Info("Model: Loading gyro settings");
+    GyroSettings* gyroSettings = this->settingReader->loadGyroSettings();
+    Log.Info("Model: Loading PID settings");
+    PIDSettings* pidSettings = this->settingReader->loadPIDSettings();
+    Log.Info("Model: Loading inclinometer settings");
+    InclinometerSettings* inclinometerSettings = this->settingReader->loadInclinometerSettings();
 
-	this->populateForceActuatorInfo(forceActuatorApplicationSettings, forceActuatorSettings);
-	this->populateHardpointActuatorInfo(hardpointActuatorApplicationSettings, hardpointActuatorSettings, positionControllerSettings);
-	this->populateHardpointMonitorInfo(hardpointMonitorApplicationSettings);
+    this->populateForceActuatorInfo(forceActuatorApplicationSettings, forceActuatorSettings);
+    this->populateHardpointActuatorInfo(hardpointActuatorApplicationSettings, hardpointActuatorSettings,
+                                        positionControllerSettings);
+    this->populateHardpointMonitorInfo(hardpointMonitorApplicationSettings);
 
-	if (this->safetyController) {
-		Log.Debug("Model: Deleting safety controller");
-		delete this->safetyController;
-	}
-	Log.Info("Model: Creating safety controller");
-	this->safetyController = new SafetyController(this->publisher, safetyControllerSettings);
+    if (this->safetyController) {
+        Log.Debug("Model: Deleting safety controller");
+        delete this->safetyController;
+    }
+    Log.Info("Model: Creating safety controller");
+    this->safetyController = new SafetyController(this->publisher, safetyControllerSettings);
 
-	if (this->displacement) {
-		Log.Debug("Model: Deleting displacement");
-		delete this->displacement;
-	}
-	Log.Info("Model: Creating displacement");
-	this->displacement = new Displacement(displacementSensorSettings, this->fpga->getSupportFPGAData(), this->publisher, this->safetyController);
+    if (this->displacement) {
+        Log.Debug("Model: Deleting displacement");
+        delete this->displacement;
+    }
+    Log.Info("Model: Creating displacement");
+    this->displacement = new Displacement(displacementSensorSettings, IFPGA::get().getSupportFPGAData(),
+                                          this->publisher, this->safetyController);
 
-	if (this->inclinometer) {
-		Log.Debug("Model: Deleting inclinometer");
-		delete this->inclinometer;
-	}
-	Log.Info("Model: Creating inclinometer");
-	this->inclinometer = new Inclinometer(this->fpga->getSupportFPGAData(), this->publisher, this->safetyController, inclinometerSettings);
+    if (this->inclinometer) {
+        Log.Debug("Model: Deleting inclinometer");
+        delete this->inclinometer;
+    }
+    Log.Info("Model: Creating inclinometer");
+    this->inclinometer = new Inclinometer(IFPGA::get().getSupportFPGAData(), this->publisher,
+                                          this->safetyController, inclinometerSettings);
 
-	if (this->positionController) {
-		Log.Debug("Model: Deleting position controller");
-		delete this->positionController;
-	}
-	Log.Info("Model: Creating position controller");
-	this->positionController = new PositionController(positionControllerSettings, hardpointActuatorSettings, this->publisher);
+    if (this->positionController) {
+        Log.Debug("Model: Deleting position controller");
+        delete this->positionController;
+    }
+    Log.Info("Model: Creating position controller");
+    this->positionController =
+            new PositionController(positionControllerSettings, hardpointActuatorSettings, this->publisher);
 
-	if (this->ilc) {
-		Log.Debug("Model: Deleting ILC");
-		delete this->ilc;
-	}
-	Log.Info("Model: Creating ILC");
-	this->ilc = new ILC(this->publisher, this->fpga, this->positionController, ilcApplicationSettings, forceActuatorApplicationSettings, forceActuatorSettings, hardpointActuatorApplicationSettings, hardpointActuatorSettings, hardpointMonitorApplicationSettings, this->safetyController);
+    if (this->ilc) {
+        Log.Debug("Model: Deleting ILC");
+        delete this->ilc;
+    }
+    Log.Info("Model: Creating ILC");
+    this->ilc = new ILC(this->publisher, this->positionController, ilcApplicationSettings,
+                        forceActuatorApplicationSettings, forceActuatorSettings,
+                        hardpointActuatorApplicationSettings, hardpointActuatorSettings,
+                        hardpointMonitorApplicationSettings, this->safetyController);
 
-	if (this->forceController) {
-		Log.Debug("Model: Deleting force controller");
-		delete this->forceController;
-	}
-	Log.Info("Model: Creating force controller");
-	this->forceController = new ForceController(forceActuatorApplicationSettings, forceActuatorSettings, pidSettings, this->publisher, this->safetyController);
+    if (this->forceController) {
+        Log.Debug("Model: Deleting force controller");
+        delete this->forceController;
+    }
+    Log.Info("Model: Creating force controller");
+    this->forceController = new ForceController(forceActuatorApplicationSettings, forceActuatorSettings,
+                                                pidSettings, this->publisher, this->safetyController);
 
-	Log.Info("Model: Updating digital input output");
-	this->digitalInputOutput->setSafetyController(this->safetyController);
+    Log.Info("Model: Updating digital input output");
+    this->digitalInputOutput->setSafetyController(this->safetyController);
 
-	if (this->accelerometer) {
-		Log.Debug("Model: Deleting accelerometer");
-		delete this->accelerometer;
-	}
-	Log.Info("Model: Creating accelerometer");
-	this->accelerometer = new Accelerometer(accelerometerSettings, this->fpga->getSupportFPGAData(), this->publisher);
+    if (this->accelerometer) {
+        Log.Debug("Model: Deleting accelerometer");
+        delete this->accelerometer;
+    }
+    Log.Info("Model: Creating accelerometer");
+    this->accelerometer = new Accelerometer(accelerometerSettings, this->publisher);
 
-	if (this->powerController) {
-		Log.Debug("Model: Deleting power controller");
-		delete this->powerController;
-	}
-	Log.Info("Model: Creating power controller");
-	this->powerController = new PowerController(this->fpga, this->expansionFPGA, this->publisher, this->safetyController);
+    if (this->powerController) {
+        Log.Debug("Model: Deleting power controller");
+        delete this->powerController;
+    }
+    Log.Info("Model: Creating power controller");
+    this->powerController =
+            new PowerController(this->publisher, this->safetyController);
 
-	if (this->automaticOperationsController) {
-		Log.Debug("Model: Deleting automatic operations controller");
-		delete this->automaticOperationsController;
-	}
-	Log.Info("Model: Creating automatic operations controller");
-	this->automaticOperationsController = new AutomaticOperationsController(this->positionController, this->forceController, this->safetyController, this->publisher, this->powerController);
+    if (this->automaticOperationsController) {
+        Log.Debug("Model: Deleting automatic operations controller");
+        delete this->automaticOperationsController;
+    }
+    Log.Info("Model: Creating automatic operations controller");
+    this->automaticOperationsController =
+            new AutomaticOperationsController(this->positionController, this->forceController,
+                                              this->safetyController, this->publisher, this->powerController);
 
-	if (this->gyro) {
-		Log.Debug("Model: Deleting gyro");
-		delete this->gyro;
-	}
-	Log.Info("Model: Creating gyro");
-	this->gyro = new Gyro(gyroSettings, this->fpga, this->publisher);
+    if (this->gyro) {
+        Log.Debug("Model: Deleting gyro");
+        delete this->gyro;
+    }
+    Log.Info("Model: Creating gyro");
+    this->gyro = new Gyro(gyroSettings, this->publisher);
 
-	Log.Info("Model: Settings applied");
+    Log.Info("Model: Settings applied");
 }
 
-void Model::queryFPGAData() {
-
-}
+void Model::queryFPGAData() {}
 
 void Model::publishFPGAData() {
-	uint16_t response[512];
-	this->fpga->writeRequestFIFO(FPGAAddresses::HealthAndStatus, 0);
-	this->fpga->readU16ResponseFIFO(response, 64*4, 20);
-	/*for(int i = 0; i < 25; i++) {
-		cout << U16ArrayUtilities::u64(response, i * 4) << " ";
-	}
-	cout << endl;*/
+    uint16_t response[512];
+    IFPGA::get().writeRequestFIFO(FPGAAddresses::HealthAndStatus, 0);
+    IFPGA::get().readU16ResponseFIFO(response, 64 * 4, 20);
+    /*for(int i = 0; i < 25; i++) {
+            cout << U16ArrayUtilities::u64(response, i * 4) << " ";
+    }
+    cout << endl;*/
 }
 
 void Model::publishStateChange(States::Type newState) {
-	Log.Debug("Model: publishStateChange(%d)", newState);
-	uint64_t state = (uint64_t)newState;
-	double timestamp = this->publisher->getTimestamp();
-	MTM1M3_logevent_summaryStateC* summaryStateData = this->publisher->getEventSummaryState();
-	summaryStateData->timestamp = timestamp;
-	summaryStateData->summaryState = (int32_t)((state & 0xFFFFFFFF00000000) >> 32);
-	this->publisher->logSummaryState();
-	MTM1M3_logevent_detailedStateC* detailedStateData = this->publisher->getEventDetailedState();
-	detailedStateData->timestamp = timestamp;
-	detailedStateData->detailedState = (int32_t)(state & 0x00000000FFFFFFFF);
-	this->publisher->logDetailedState();
+    Log.Debug("Model: publishStateChange(%d)", newState);
+    uint64_t state = (uint64_t)newState;
+    double timestamp = this->publisher->getTimestamp();
+    MTM1M3_logevent_summaryStateC* summaryStateData = this->publisher->getEventSummaryState();
+    summaryStateData->summaryState = (int32_t)((state & 0xFFFFFFFF00000000) >> 32);
+    this->publisher->logSummaryState();
+    MTM1M3_logevent_detailedStateC* detailedStateData = this->publisher->getEventDetailedState();
+    detailedStateData->detailedState = (int32_t)(state & 0x00000000FFFFFFFF);
+    this->publisher->logDetailedState();
 }
 
 void Model::publishRecommendedSettings() {
-	Log.Debug("Model: publishRecommendedSettings()");
-	RecommendedApplicationSettings* recommendedApplicationSettings = this->settingReader->loadRecommendedApplicationSettings();
-	MTM1M3_logevent_settingVersionsC* data = this->publisher->getEventSettingVersions();
-	data->timestamp = this->publisher->getTimestamp();
-	data->recommendedSettingsVersion = "";
-	for(uint32_t i = 0; i < recommendedApplicationSettings->RecommendedSettings.size(); i++) {
-		data->recommendedSettingsVersion += recommendedApplicationSettings->RecommendedSettings[i] + ",";
-	}
-	this->publisher->logSettingVersions();
+    Log.Debug("Model: publishRecommendedSettings()");
+    RecommendedApplicationSettings* recommendedApplicationSettings =
+            this->settingReader->loadRecommendedApplicationSettings();
+    MTM1M3_logevent_settingVersionsC* data = this->publisher->getEventSettingVersions();
+    data->recommendedSettingsVersion = "";
+    for (uint32_t i = 0; i < recommendedApplicationSettings->RecommendedSettings.size(); i++) {
+        data->recommendedSettingsVersion += recommendedApplicationSettings->RecommendedSettings[i] + ",";
+    }
+    this->publisher->logSettingVersions();
 }
 
 void Model::publishOuterLoop(double executionTime) {
-	Log.Trace("Model: publishOuterLoop()");
-	MTM1M3_outerLoopDataC* data = this->publisher->getOuterLoopData();
-	data->timestamp = this->publisher->getTimestamp();
-	data->executionTime = executionTime;
-	this->publisher->putOuterLoopData();
+    Log.Trace("Model: publishOuterLoop()");
+    MTM1M3_outerLoopDataC* data = this->publisher->getOuterLoopData();
+    data->executionTime = executionTime;
+    this->publisher->putOuterLoopData();
 }
 
-void Model::shutdown() {
-	pthread_mutex_unlock(&this->mutex);
-}
+void Model::shutdown() { pthread_mutex_unlock(&this->mutex); }
 
 void Model::waitForShutdown() {
-	pthread_mutex_lock(&this->mutex);
-	pthread_mutex_unlock(&this->mutex);
+    pthread_mutex_lock(&this->mutex);
+    pthread_mutex_unlock(&this->mutex);
 }
 
-void Model::populateForceActuatorInfo(ForceActuatorApplicationSettings* forceActuatorApplicationSettings, ForceActuatorSettings* forceActuatorSettings) {
-	Log.Debug("Model: populateForceActuatorInfo()");
-	MTM1M3_logevent_forceActuatorInfoC* forceInfo = this->publisher->getEventForceActuatorInfo();
-	for(int i = 0; i < FA_COUNT; i++) {
-		ForceActuatorTableRow row = forceActuatorApplicationSettings->Table[i];
-		forceInfo->referenceId[row.Index] = row.ActuatorID;
-		forceInfo->modbusSubnet[row.Index] = row.Subnet;
-		forceInfo->modbusAddress[row.Index] = row.Address;
-		forceInfo->actuatorType[row.Index] = row.Type;
-		forceInfo->actuatorOrientation[row.Index] = row.Orientation;
-		forceInfo->xPosition[row.Index] = row.XPosition;
-		forceInfo->yPosition[row.Index] = row.YPosition;
-		forceInfo->zPosition[row.Index] = row.ZPosition;
-	}
+void Model::populateForceActuatorInfo(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+                                      ForceActuatorSettings* forceActuatorSettings) {
+    Log.Debug("Model: populateForceActuatorInfo()");
+    MTM1M3_logevent_forceActuatorInfoC* forceInfo = this->publisher->getEventForceActuatorInfo();
+    for (int i = 0; i < FA_COUNT; i++) {
+        ForceActuatorTableRow row = forceActuatorApplicationSettings->Table[i];
+        forceInfo->referenceId[row.Index] = row.ActuatorID;
+        forceInfo->modbusSubnet[row.Index] = row.Subnet;
+        forceInfo->modbusAddress[row.Index] = row.Address;
+        forceInfo->actuatorType[row.Index] = row.Type;
+        forceInfo->actuatorOrientation[row.Index] = row.Orientation;
+        forceInfo->xPosition[row.Index] = row.XPosition;
+        forceInfo->yPosition[row.Index] = row.YPosition;
+        forceInfo->zPosition[row.Index] = row.ZPosition;
+    }
 }
 
-void Model::populateHardpointActuatorInfo(HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings, HardpointActuatorSettings* hardpointActuatorSettings, PositionControllerSettings* positionControllerSettings) {
-	Log.Debug("Model: populateHardpointActuatorInfo()");
-	MTM1M3_logevent_hardpointActuatorInfoC* hardpointInfo = this->publisher->getEventHardpointActuatorInfo();
-	for(int i = 0; i < HP_COUNT; i++) {
-		HardpointActuatorTableRow row = hardpointActuatorApplicationSettings->Table[i];
-		hardpointInfo->referenceId[row.Index] = row.ActuatorID;
-		hardpointInfo->modbusSubnet[row.Index] = row.Subnet;
-		hardpointInfo->modbusAddress[row.Index] = row.Address;
-		hardpointInfo->xPosition[row.Index] = row.XPosition;
-		hardpointInfo->yPosition[row.Index] = row.YPosition;
-		hardpointInfo->zPosition[row.Index] = row.ZPosition;
-	}
-	hardpointInfo->referencePosition[0] = positionControllerSettings->ReferencePositionEncoder1;
-	hardpointInfo->referencePosition[1] = positionControllerSettings->ReferencePositionEncoder2;
-	hardpointInfo->referencePosition[2] = positionControllerSettings->ReferencePositionEncoder3;
-	hardpointInfo->referencePosition[3] = positionControllerSettings->ReferencePositionEncoder4;
-	hardpointInfo->referencePosition[4] = positionControllerSettings->ReferencePositionEncoder5;
-	hardpointInfo->referencePosition[5] = positionControllerSettings->ReferencePositionEncoder6;
+void Model::populateHardpointActuatorInfo(
+        HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings,
+        HardpointActuatorSettings* hardpointActuatorSettings,
+        PositionControllerSettings* positionControllerSettings) {
+    Log.Debug("Model: populateHardpointActuatorInfo()");
+    MTM1M3_logevent_hardpointActuatorInfoC* hardpointInfo = this->publisher->getEventHardpointActuatorInfo();
+    for (int i = 0; i < HP_COUNT; i++) {
+        HardpointActuatorTableRow row = hardpointActuatorApplicationSettings->Table[i];
+        hardpointInfo->referenceId[row.Index] = row.ActuatorID;
+        hardpointInfo->modbusSubnet[row.Index] = row.Subnet;
+        hardpointInfo->modbusAddress[row.Index] = row.Address;
+        hardpointInfo->xPosition[row.Index] = row.XPosition;
+        hardpointInfo->yPosition[row.Index] = row.YPosition;
+        hardpointInfo->zPosition[row.Index] = row.ZPosition;
+    }
+    hardpointInfo->referencePosition[0] = positionControllerSettings->ReferencePositionEncoder1;
+    hardpointInfo->referencePosition[1] = positionControllerSettings->ReferencePositionEncoder2;
+    hardpointInfo->referencePosition[2] = positionControllerSettings->ReferencePositionEncoder3;
+    hardpointInfo->referencePosition[3] = positionControllerSettings->ReferencePositionEncoder4;
+    hardpointInfo->referencePosition[4] = positionControllerSettings->ReferencePositionEncoder5;
+    hardpointInfo->referencePosition[5] = positionControllerSettings->ReferencePositionEncoder6;
 }
 
-void Model::populateHardpointMonitorInfo(HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings) {
-	Log.Debug("Model: populateHardpointMonitorInfo()");
-	MTM1M3_logevent_hardpointMonitorInfoC* hardpointMonitorInfo = this->publisher->getEventHardpointMonitorInfo();
-	for(int i = 0; i < HM_COUNT; i++) {
-		HardpointMonitorTableRow row = hardpointMonitorApplicationSettings->Table[i];
-		hardpointMonitorInfo->referenceId[row.Index] = row.ActuatorID;
-		hardpointMonitorInfo->modbusSubnet[row.Index] = row.Subnet;
-		hardpointMonitorInfo->modbusAddress[row.Index] = row.Address;
-	}
+void Model::populateHardpointMonitorInfo(
+        HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings) {
+    Log.Debug("Model: populateHardpointMonitorInfo()");
+    MTM1M3_logevent_hardpointMonitorInfoC* hardpointMonitorInfo =
+            this->publisher->getEventHardpointMonitorInfo();
+    for (int i = 0; i < HM_COUNT; i++) {
+        HardpointMonitorTableRow row = hardpointMonitorApplicationSettings->Table[i];
+        hardpointMonitorInfo->referenceId[row.Index] = row.ActuatorID;
+        hardpointMonitorInfo->modbusSubnet[row.Index] = row.Subnet;
+        hardpointMonitorInfo->modbusAddress[row.Index] = row.Address;
+    }
 }
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/Model/Model.h
+++ b/Controller/src/LSST/M1M3/SS/Model/Model.h
@@ -19,8 +19,6 @@ namespace SS {
 
 class SettingReader;
 class M1M3SSPublisher;
-class FPGA;
-class ExpansionFPGA;
 class Displacement;
 class Inclinometer;
 class ILC;
@@ -45,67 +43,70 @@ class PositionControllerSettings;
 
 class Model {
 private:
-	SettingReader* settingReader;
-	M1M3SSPublisher* publisher;
-	FPGA* fpga;
-	ExpansionFPGA* expansionFPGA;
-	Displacement* displacement;
-	Inclinometer* inclinometer;
-	ILC* ilc;
-	ForceController* forceController;
-	SafetyController* safetyController;
-	PositionController* positionController;
-	Accelerometer* accelerometer;
-	PowerController* powerController;
-	AutomaticOperationsController* automaticOperationsController;
-	Gyro* gyro;
-	ProfileController profileController;
-	DigitalInputOutput* digitalInputOutput;
+    SettingReader* settingReader;
+    M1M3SSPublisher* publisher;
+    Displacement* displacement;
+    Inclinometer* inclinometer;
+    ILC* ilc;
+    ForceController* forceController;
+    SafetyController* safetyController;
+    PositionController* positionController;
+    Accelerometer* accelerometer;
+    PowerController* powerController;
+    AutomaticOperationsController* automaticOperationsController;
+    Gyro* gyro;
+    ProfileController profileController;
+    DigitalInputOutput* digitalInputOutput;
 
-	pthread_mutex_t mutex;
+    pthread_mutex_t mutex;
 
-	double cachedTimestamp;
+    double cachedTimestamp;
 
 public:
-	Model(SettingReader* settingReader, M1M3SSPublisher* publisher, FPGA* fpga, ExpansionFPGA* expansionFPGA, DigitalInputOutput* digitalInputOutput);
-	virtual ~Model();
+    Model(SettingReader* settingReader, M1M3SSPublisher* publisher, DigitalInputOutput* digitalInputOutput);
+    virtual ~Model();
 
-	inline SettingReader* getSettingReader() { return this->settingReader; }
-	inline M1M3SSPublisher* getPublisher() { return this->publisher; }
-	inline FPGA* getFPGA() { return this->fpga; }
-	inline ExpansionFPGA* getExpansionFPGA() { return this->expansionFPGA; }
-	inline Displacement* getDisplacement() { return this->displacement; }
-	inline Inclinometer* getInclinometer() { return this->inclinometer; }
-	inline ILC* getILC() { return this->ilc; }
-	inline ForceController* getForceController() { return this->forceController; }
-	inline SafetyController* getSafetyController() { return this->safetyController; }
-	inline PositionController* getPositionController() { return this->positionController; }
-	inline DigitalInputOutput* getDigitalInputOutput() { return this->digitalInputOutput; }
-	inline Accelerometer* getAccelerometer() { return this->accelerometer; }
-	inline PowerController* getPowerController() { return this->powerController; }
-	inline AutomaticOperationsController* getAutomaticOperationsController() { return this->automaticOperationsController; }
-	inline Gyro* getGyro() { return this->gyro; }
-	inline ProfileController* getProfileController() { return &this->profileController; }
+    inline SettingReader* getSettingReader() { return this->settingReader; }
+    inline M1M3SSPublisher* getPublisher() { return this->publisher; }
+    inline Displacement* getDisplacement() { return this->displacement; }
+    inline Inclinometer* getInclinometer() { return this->inclinometer; }
+    inline ILC* getILC() { return this->ilc; }
+    inline ForceController* getForceController() { return this->forceController; }
+    inline SafetyController* getSafetyController() { return this->safetyController; }
+    inline PositionController* getPositionController() { return this->positionController; }
+    inline DigitalInputOutput* getDigitalInputOutput() { return this->digitalInputOutput; }
+    inline Accelerometer* getAccelerometer() { return this->accelerometer; }
+    inline PowerController* getPowerController() { return this->powerController; }
+    inline AutomaticOperationsController* getAutomaticOperationsController() {
+        return this->automaticOperationsController;
+    }
+    inline Gyro* getGyro() { return this->gyro; }
+    inline ProfileController* getProfileController() { return &this->profileController; }
 
-	void setCachedTimestamp(double timestamp) { this->cachedTimestamp = timestamp; }
-	double getCachedTimestamp() { return this->cachedTimestamp; }
+    void setCachedTimestamp(double timestamp) { this->cachedTimestamp = timestamp; }
+    double getCachedTimestamp() { return this->cachedTimestamp; }
 
-	void loadSettings(std::string settingsToApply);
+    void loadSettings(std::string settingsToApply);
 
-	void queryFPGAData();
-	void publishFPGAData();
+    void queryFPGAData();
+    void publishFPGAData();
 
-	void publishStateChange(States::Type newState);
-	void publishRecommendedSettings();
-	void publishOuterLoop(double executionTime);
+    void publishStateChange(States::Type newState);
+    void publishRecommendedSettings();
+    void publishOuterLoop(double executionTime);
 
-	void shutdown();
-	void waitForShutdown();
+    void shutdown();
+    void waitForShutdown();
 
 private:
-	void populateForceActuatorInfo(ForceActuatorApplicationSettings* forceActuatorApplicationSettings, ForceActuatorSettings* forceActuatorSettings);
-	void populateHardpointActuatorInfo(HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings, HardpointActuatorSettings* hardpointActuatorSettings, PositionControllerSettings* positionControllerSettings);
-	void populateHardpointMonitorInfo(HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings);
+    void populateForceActuatorInfo(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+                                   ForceActuatorSettings* forceActuatorSettings);
+    void populateHardpointActuatorInfo(
+            HardpointActuatorApplicationSettings* hardpointActuatorApplicationSettings,
+            HardpointActuatorSettings* hardpointActuatorSettings,
+            PositionControllerSettings* positionControllerSettings);
+    void populateHardpointMonitorInfo(
+            HardpointMonitorApplicationSettings* hardpointMonitorApplicationSettings);
 };
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/PowerController/PowerController.cpp
+++ b/Controller/src/LSST/M1M3/SS/PowerController/PowerController.cpp
@@ -1,15 +1,6 @@
-/*
- * PowerController.cpp
- *
- *  Created on: Dec 7, 2017
- *      Author: ccontaxis
- */
-
 #include <PowerController.h>
-#include <FPGA.h>
 #include <FPGAAddresses.h>
 #include <SupportFPGAData.h>
-#include <ExpansionFPGA.h>
 #include <M1M3SSPublisher.h>
 #include <SafetyController.h>
 #include <Timestamp.h>
@@ -22,184 +13,199 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-PowerController::PowerController(FPGA* fpga, ExpansionFPGA* expansionFPGA, M1M3SSPublisher* publisher, SafetyController* safetyController) {
-	Log.Debug("PowerController: PowerController()");
-	this->fpga = fpga;
-	this->fpgaData = this->fpga->getSupportFPGAData();
-	this->expansionFPGA = expansionFPGA;
-	this->publisher = publisher;
-	this->safetyController = safetyController;
+PowerController::PowerController(M1M3SSPublisher* publisher, SafetyController* safetyController) {
+    Log.Debug("PowerController: PowerController()");
+    this->publisher = publisher;
+    this->safetyController = safetyController;
 
-	this->powerSupplyData = this->publisher->getPowerSupplyData();
-	this->powerStatus = this->publisher->getEventPowerStatus();
-	this->powerSupplyStatus = this->publisher->getEventPowerSupplyStatus();
-	this->powerWarning = this->publisher->getEventPowerWarning();
+    this->powerSupplyData = this->publisher->getPowerSupplyData();
+    this->powerStatus = this->publisher->getEventPowerStatus();
+    this->powerSupplyStatus = this->publisher->getEventPowerSupplyStatus();
+    this->powerWarning = this->publisher->getEventPowerWarning();
 
-	this->lastPowerTimestamp = 0;
+    this->lastPowerTimestamp = 0;
 
-	memset(this->powerSupplyData, 0, sizeof(MTM1M3_powerSupplyDataC));
-	memset(this->powerStatus, 0, sizeof(MTM1M3_logevent_powerStatusC));
-	memset(this->powerSupplyStatus, 0, sizeof(MTM1M3_logevent_powerSupplyStatusC));
-	memset(this->powerWarning, 0, sizeof(MTM1M3_logevent_powerWarningC));
+    memset(this->powerSupplyData, 0, sizeof(MTM1M3_powerSupplyDataC));
+    memset(this->powerStatus, 0, sizeof(MTM1M3_logevent_powerStatusC));
+    memset(this->powerSupplyStatus, 0, sizeof(MTM1M3_logevent_powerSupplyStatusC));
+    memset(this->powerWarning, 0, sizeof(MTM1M3_logevent_powerWarningC));
 }
 
 void PowerController::processData() {
-	// TODO: Handle no data available
-	// TODO: Handle limits, push to safety controller
-	Log.Trace("PowerController: processData()");
-	if (this->fpgaData->PowerSupplyTimestamp != this->lastPowerTimestamp) {
-		this->lastPowerTimestamp = this->fpgaData->PowerSupplyTimestamp;
-		double timestamp = Timestamp::fromFPGA(this->fpgaData->PowerSupplyTimestamp);
-		this->powerStatus->timestamp = timestamp;
-		this->powerStatus->auxPowerNetworkAOutputOn = (this->fpgaData->PowerSupplyStates & 0x01) != 0;
-		this->powerStatus->auxPowerNetworkBOutputOn = (this->fpgaData->PowerSupplyStates & 0x02) != 0;
-		this->powerStatus->auxPowerNetworkCOutputOn = (this->fpgaData->PowerSupplyStates & 0x04) != 0;
-		this->powerStatus->auxPowerNetworkDOutputOn = (this->fpgaData->PowerSupplyStates & 0x08) != 0;
-		this->powerStatus->powerNetworkAOutputOn = (this->fpgaData->PowerSupplyStates & 0x10) != 0;
-		this->powerStatus->powerNetworkBOutputOn = (this->fpgaData->PowerSupplyStates & 0x20) != 0;
-		this->powerStatus->powerNetworkCOutputOn = (this->fpgaData->PowerSupplyStates & 0x40) != 0;
-		this->powerStatus->powerNetworkDOutputOn = (this->fpgaData->PowerSupplyStates & 0x80) != 0;
-		this->publisher->tryLogPowerStatus();
-		this->powerWarning->timestamp = timestamp;
-		this->powerWarning->auxPowerNetworkAOutputMismatch = this->powerStatus->auxPowerNetworkACommandedOn != this->powerStatus->auxPowerNetworkAOutputOn;
-		this->powerWarning->auxPowerNetworkBOutputMismatch = this->powerStatus->auxPowerNetworkBCommandedOn != this->powerStatus->auxPowerNetworkBOutputOn;
-		this->powerWarning->auxPowerNetworkCOutputMismatch = this->powerStatus->auxPowerNetworkCCommandedOn != this->powerStatus->auxPowerNetworkCOutputOn;
-		this->powerWarning->auxPowerNetworkDOutputMismatch = this->powerStatus->auxPowerNetworkDCommandedOn != this->powerStatus->auxPowerNetworkDOutputOn;
-		this->powerWarning->powerNetworkAOutputMismatch = this->powerStatus->powerNetworkACommandedOn != this->powerStatus->powerNetworkAOutputOn;
-		this->powerWarning->powerNetworkBOutputMismatch = this->powerStatus->powerNetworkBCommandedOn != this->powerStatus->powerNetworkBOutputOn;
-		this->powerWarning->powerNetworkCOutputMismatch = this->powerStatus->powerNetworkCCommandedOn != this->powerStatus->powerNetworkCOutputOn;
-		this->powerWarning->powerNetworkDOutputMismatch = this->powerStatus->powerNetworkDCommandedOn != this->powerStatus->powerNetworkDOutputOn;
-		this->publisher->tryLogPowerWarning();
-	}
-	double timestamp = this->publisher->getTimestamp();
-	this->expansionFPGA->sample();
-	float sample[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-	this->expansionFPGA->readSlot1(sample);
-	this->powerSupplyData->timestamp = timestamp;
-	this->powerSupplyData->powerNetworkACurrent = sample[0];
-	this->powerSupplyData->powerNetworkBCurrent = sample[1];
-	this->powerSupplyData->powerNetworkCCurrent = sample[2];
-	this->powerSupplyData->powerNetworkDCurrent = sample[3];
-	this->powerSupplyData->lightPowerNetworkCurrent = sample[4];
-	this->powerSupplyData->controlsPowerNetworkCurrent = sample[5];
-	this->publisher->putPowerSupplyData();
+    // TODO: Handle no data available
+    // TODO: Handle limits, push to safety controller
+    Log.Trace("PowerController: processData()");
+    SupportFPGAData* fpgaData = IFPGA::get().getSupportFPGAData();
+
+    if (fpgaData->PowerSupplyTimestamp != this->lastPowerTimestamp) {
+        this->lastPowerTimestamp = fpgaData->PowerSupplyTimestamp;
+        double timestamp = Timestamp::fromFPGA(fpgaData->PowerSupplyTimestamp);
+        this->powerStatus->timestamp = timestamp;
+        this->powerStatus->auxPowerNetworkAOutputOn = (fpgaData->PowerSupplyStates & 0x01) != 0;
+        this->powerStatus->auxPowerNetworkBOutputOn = (fpgaData->PowerSupplyStates & 0x02) != 0;
+        this->powerStatus->auxPowerNetworkCOutputOn = (fpgaData->PowerSupplyStates & 0x04) != 0;
+        this->powerStatus->auxPowerNetworkDOutputOn = (fpgaData->PowerSupplyStates & 0x08) != 0;
+        this->powerStatus->powerNetworkAOutputOn = (fpgaData->PowerSupplyStates & 0x10) != 0;
+        this->powerStatus->powerNetworkBOutputOn = (fpgaData->PowerSupplyStates & 0x20) != 0;
+        this->powerStatus->powerNetworkCOutputOn = (fpgaData->PowerSupplyStates & 0x40) != 0;
+        this->powerStatus->powerNetworkDOutputOn = (fpgaData->PowerSupplyStates & 0x80) != 0;
+        this->publisher->tryLogPowerStatus();
+        this->powerWarning->timestamp = timestamp;
+        this->powerWarning->auxPowerNetworkAOutputMismatch =
+                this->powerStatus->auxPowerNetworkACommandedOn != this->powerStatus->auxPowerNetworkAOutputOn;
+        this->powerWarning->auxPowerNetworkBOutputMismatch =
+                this->powerStatus->auxPowerNetworkBCommandedOn != this->powerStatus->auxPowerNetworkBOutputOn;
+        this->powerWarning->auxPowerNetworkCOutputMismatch =
+                this->powerStatus->auxPowerNetworkCCommandedOn != this->powerStatus->auxPowerNetworkCOutputOn;
+        this->powerWarning->auxPowerNetworkDOutputMismatch =
+                this->powerStatus->auxPowerNetworkDCommandedOn != this->powerStatus->auxPowerNetworkDOutputOn;
+        this->powerWarning->powerNetworkAOutputMismatch =
+                this->powerStatus->powerNetworkACommandedOn != this->powerStatus->powerNetworkAOutputOn;
+        this->powerWarning->powerNetworkBOutputMismatch =
+                this->powerStatus->powerNetworkBCommandedOn != this->powerStatus->powerNetworkBOutputOn;
+        this->powerWarning->powerNetworkCOutputMismatch =
+                this->powerStatus->powerNetworkCCommandedOn != this->powerStatus->powerNetworkCOutputOn;
+        this->powerWarning->powerNetworkDOutputMismatch =
+                this->powerStatus->powerNetworkDCommandedOn != this->powerStatus->powerNetworkDOutputOn;
+        this->publisher->tryLogPowerWarning();
+    }
+    double timestamp = this->publisher->getTimestamp();
+    IExpansionFPGA::get().sample();
+    float sample[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    IExpansionFPGA::get().readSlot1(sample);
+    this->powerSupplyData->timestamp = timestamp;
+    this->powerSupplyData->powerNetworkACurrent = sample[0];
+    this->powerSupplyData->powerNetworkBCurrent = sample[1];
+    this->powerSupplyData->powerNetworkCCurrent = sample[2];
+    this->powerSupplyData->powerNetworkDCurrent = sample[3];
+    this->powerSupplyData->lightPowerNetworkCurrent = sample[4];
+    this->powerSupplyData->controlsPowerNetworkCurrent = sample[5];
+    this->publisher->putPowerSupplyData();
 }
 
 void PowerController::setBothPowerNetworks(bool on) {
-	Log.Info("PowerController: setBothPowerNetworks(%d)", on);
-	this->powerStatus->powerNetworkACommandedOn = on;
-	this->powerStatus->powerNetworkBCommandedOn = on;
-	this->powerStatus->powerNetworkCCommandedOn = on;
-	this->powerStatus->powerNetworkDCommandedOn = on;
-	this->powerStatus->auxPowerNetworkACommandedOn = on;
-	this->powerStatus->auxPowerNetworkBCommandedOn = on;
-	this->powerStatus->auxPowerNetworkCCommandedOn = on;
-	this->powerStatus->auxPowerNetworkDCommandedOn = on;
-	uint16_t buffer[16] = {
-			FPGAAddresses::DCPowerNetworkAOn, (uint16_t)this->powerStatus->powerNetworkACommandedOn,
-			FPGAAddresses::DCPowerNetworkBOn, (uint16_t)this->powerStatus->powerNetworkBCommandedOn,
-			FPGAAddresses::DCPowerNetworkCOn, (uint16_t)this->powerStatus->powerNetworkCCommandedOn,
-			FPGAAddresses::DCPowerNetworkDOn, (uint16_t)this->powerStatus->powerNetworkDCommandedOn,
-			FPGAAddresses::DCAuxPowerNetworkAOn, (uint16_t)this->powerStatus->auxPowerNetworkACommandedOn,
-			FPGAAddresses::DCAuxPowerNetworkBOn, (uint16_t)this->powerStatus->auxPowerNetworkBCommandedOn,
-			FPGAAddresses::DCAuxPowerNetworkCOn, (uint16_t)this->powerStatus->auxPowerNetworkCCommandedOn,
-			FPGAAddresses::DCAuxPowerNetworkDOn, (uint16_t)this->powerStatus->auxPowerNetworkDCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 16, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setBothPowerNetworks(%d)", on);
+    this->powerStatus->powerNetworkACommandedOn = on;
+    this->powerStatus->powerNetworkBCommandedOn = on;
+    this->powerStatus->powerNetworkCCommandedOn = on;
+    this->powerStatus->powerNetworkDCommandedOn = on;
+    this->powerStatus->auxPowerNetworkACommandedOn = on;
+    this->powerStatus->auxPowerNetworkBCommandedOn = on;
+    this->powerStatus->auxPowerNetworkCCommandedOn = on;
+    this->powerStatus->auxPowerNetworkDCommandedOn = on;
+    uint16_t buffer[16] = {
+            FPGAAddresses::DCPowerNetworkAOn,    (uint16_t)this->powerStatus->powerNetworkACommandedOn,
+            FPGAAddresses::DCPowerNetworkBOn,    (uint16_t)this->powerStatus->powerNetworkBCommandedOn,
+            FPGAAddresses::DCPowerNetworkCOn,    (uint16_t)this->powerStatus->powerNetworkCCommandedOn,
+            FPGAAddresses::DCPowerNetworkDOn,    (uint16_t)this->powerStatus->powerNetworkDCommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkAOn, (uint16_t)this->powerStatus->auxPowerNetworkACommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkBOn, (uint16_t)this->powerStatus->auxPowerNetworkBCommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkCOn, (uint16_t)this->powerStatus->auxPowerNetworkCCommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkDOn, (uint16_t)this->powerStatus->auxPowerNetworkDCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 16, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setAllPowerNetworks(bool on) {
-	Log.Info("PowerController: setAllPowerNetworks(%d)", on);
-	this->powerStatus->powerNetworkACommandedOn = on;
-	this->powerStatus->powerNetworkBCommandedOn = on;
-	this->powerStatus->powerNetworkCCommandedOn = on;
-	this->powerStatus->powerNetworkDCommandedOn = on;
-	uint16_t buffer[8] = {
-			FPGAAddresses::DCPowerNetworkAOn, (uint16_t)this->powerStatus->powerNetworkACommandedOn,
-			FPGAAddresses::DCPowerNetworkBOn, (uint16_t)this->powerStatus->powerNetworkBCommandedOn,
-			FPGAAddresses::DCPowerNetworkCOn, (uint16_t)this->powerStatus->powerNetworkCCommandedOn,
-			FPGAAddresses::DCPowerNetworkDOn, (uint16_t)this->powerStatus->powerNetworkDCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 8, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setAllPowerNetworks(%d)", on);
+    this->powerStatus->powerNetworkACommandedOn = on;
+    this->powerStatus->powerNetworkBCommandedOn = on;
+    this->powerStatus->powerNetworkCCommandedOn = on;
+    this->powerStatus->powerNetworkDCommandedOn = on;
+    uint16_t buffer[8] = {
+            FPGAAddresses::DCPowerNetworkAOn, (uint16_t)this->powerStatus->powerNetworkACommandedOn,
+            FPGAAddresses::DCPowerNetworkBOn, (uint16_t)this->powerStatus->powerNetworkBCommandedOn,
+            FPGAAddresses::DCPowerNetworkCOn, (uint16_t)this->powerStatus->powerNetworkCCommandedOn,
+            FPGAAddresses::DCPowerNetworkDOn, (uint16_t)this->powerStatus->powerNetworkDCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 8, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setPowerNetworkA(bool on) {
-	Log.Info("PowerController: setPowerNetworkA(%d)", on);
-	this->powerStatus->powerNetworkACommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCPowerNetworkAOn, (uint16_t)this->powerStatus->powerNetworkACommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setPowerNetworkA(%d)", on);
+    this->powerStatus->powerNetworkACommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCPowerNetworkAOn,
+                          (uint16_t)this->powerStatus->powerNetworkACommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setPowerNetworkB(bool on) {
-	Log.Info("PowerController: setPowerNetworkB(%d)", on);
-	this->powerStatus->powerNetworkBCommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCPowerNetworkBOn, (uint16_t)this->powerStatus->powerNetworkBCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setPowerNetworkB(%d)", on);
+    this->powerStatus->powerNetworkBCommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCPowerNetworkBOn,
+                          (uint16_t)this->powerStatus->powerNetworkBCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setPowerNetworkC(bool on) {
-	Log.Info("PowerController: setPowerNetworkC(%d)", on);
-	this->powerStatus->powerNetworkCCommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCPowerNetworkCOn, (uint16_t)this->powerStatus->powerNetworkCCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setPowerNetworkC(%d)", on);
+    this->powerStatus->powerNetworkCCommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCPowerNetworkCOn,
+                          (uint16_t)this->powerStatus->powerNetworkCCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setPowerNetworkD(bool on) {
-	Log.Info("PowerController: setPowerNetworkD(%d)", on);
-	this->powerStatus->powerNetworkDCommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCPowerNetworkDOn, (uint16_t)this->powerStatus->powerNetworkDCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setPowerNetworkD(%d)", on);
+    this->powerStatus->powerNetworkDCommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCPowerNetworkDOn,
+                          (uint16_t)this->powerStatus->powerNetworkDCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setAllAuxPowerNetworks(bool on) {
-	Log.Info("PowerController: setAllAuxPowerNetworks(%d)", on);
-	this->powerStatus->auxPowerNetworkACommandedOn = on;
-	this->powerStatus->auxPowerNetworkBCommandedOn = on;
-	this->powerStatus->auxPowerNetworkCCommandedOn = on;
-	this->powerStatus->auxPowerNetworkDCommandedOn = on;
-	uint16_t buffer[8] = {
-				FPGAAddresses::DCAuxPowerNetworkAOn, (uint16_t)this->powerStatus->auxPowerNetworkACommandedOn,
-				FPGAAddresses::DCAuxPowerNetworkBOn, (uint16_t)this->powerStatus->auxPowerNetworkBCommandedOn,
-				FPGAAddresses::DCAuxPowerNetworkCOn, (uint16_t)this->powerStatus->auxPowerNetworkCCommandedOn,
-				FPGAAddresses::DCAuxPowerNetworkDOn, (uint16_t)this->powerStatus->auxPowerNetworkDCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 8, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setAllAuxPowerNetworks(%d)", on);
+    this->powerStatus->auxPowerNetworkACommandedOn = on;
+    this->powerStatus->auxPowerNetworkBCommandedOn = on;
+    this->powerStatus->auxPowerNetworkCCommandedOn = on;
+    this->powerStatus->auxPowerNetworkDCommandedOn = on;
+    uint16_t buffer[8] = {
+            FPGAAddresses::DCAuxPowerNetworkAOn, (uint16_t)this->powerStatus->auxPowerNetworkACommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkBOn, (uint16_t)this->powerStatus->auxPowerNetworkBCommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkCOn, (uint16_t)this->powerStatus->auxPowerNetworkCCommandedOn,
+            FPGAAddresses::DCAuxPowerNetworkDOn, (uint16_t)this->powerStatus->auxPowerNetworkDCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 8, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setAuxPowerNetworkA(bool on) {
-	Log.Info("PowerController: setAuxPowerNetworkA(%d)", on);
-	this->powerStatus->auxPowerNetworkACommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCAuxPowerNetworkAOn, (uint16_t)this->powerStatus->auxPowerNetworkACommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setAuxPowerNetworkA(%d)", on);
+    this->powerStatus->auxPowerNetworkACommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCAuxPowerNetworkAOn,
+                          (uint16_t)this->powerStatus->auxPowerNetworkACommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setAuxPowerNetworkB(bool on) {
-	Log.Info("PowerController: setAuxPowerNetworkB(%d)", on);
-	this->powerStatus->auxPowerNetworkBCommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCAuxPowerNetworkBOn, (uint16_t)this->powerStatus->auxPowerNetworkBCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setAuxPowerNetworkB(%d)", on);
+    this->powerStatus->auxPowerNetworkBCommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCAuxPowerNetworkBOn,
+                          (uint16_t)this->powerStatus->auxPowerNetworkBCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setAuxPowerNetworkC(bool on) {
-	Log.Info("PowerController: setAuxPowerNetworkC(%d)", on);
-	this->powerStatus->auxPowerNetworkCCommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCAuxPowerNetworkCOn, (uint16_t)this->powerStatus->auxPowerNetworkCCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setAuxPowerNetworkC(%d)", on);
+    this->powerStatus->auxPowerNetworkCCommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCAuxPowerNetworkCOn,
+                          (uint16_t)this->powerStatus->auxPowerNetworkCCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 void PowerController::setAuxPowerNetworkD(bool on) {
-	Log.Info("PowerController: setAuxPowerNetworkD(%d)", on);
-	this->powerStatus->auxPowerNetworkDCommandedOn = on;
-	uint16_t buffer[2] = { FPGAAddresses::DCAuxPowerNetworkDOn, (uint16_t)this->powerStatus->auxPowerNetworkDCommandedOn };
-	this->fpga->writeCommandFIFO(buffer, 2, 0);
-	this->publisher->tryLogPowerStatus();
+    Log.Info("PowerController: setAuxPowerNetworkD(%d)", on);
+    this->powerStatus->auxPowerNetworkDCommandedOn = on;
+    uint16_t buffer[2] = {FPGAAddresses::DCAuxPowerNetworkDOn,
+                          (uint16_t)this->powerStatus->auxPowerNetworkDCommandedOn};
+    IFPGA::get().writeCommandFIFO(buffer, 2, 0);
+    this->publisher->tryLogPowerStatus();
 }
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/PowerController/PowerController.h
+++ b/Controller/src/LSST/M1M3/SS/PowerController/PowerController.h
@@ -1,14 +1,9 @@
-/*
- * PowerController.h
- *
- *  Created on: Dec 7, 2017
- *      Author: ccontaxis
- */
-
 #ifndef POWERCONTROLLER_H_
 #define POWERCONTROLLER_H_
 
 #include <DataTypes.h>
+#include <IFPGA.h>
+#include <IExpansionFPGA.h>
 
 struct MTM1M3_powerSupplyDataC;
 struct MTM1M3_logevent_powerStatusC;
@@ -19,9 +14,7 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-class FPGA;
 struct SupportFPGAData;
-class ExpansionFPGA;
 class M1M3SSPublisher;
 class SafetyController;
 
@@ -30,9 +23,6 @@ class SafetyController;
  */
 class PowerController {
 private:
-	FPGA* fpga;
-	SupportFPGAData* fpgaData;
-	ExpansionFPGA* expansionFPGA;
 	M1M3SSPublisher* publisher;
 	SafetyController* safetyController;
 
@@ -46,12 +36,10 @@ private:
 public:
 	/*!
 	 * Instantiates the power controller.
-	 * @param[in] fpga The fpga.
-	 * @param[in] expansionFPGA The expansion fpga.
 	 * @param[in] publisher The publisher.
 	 * @param[in] safetyController The safety controller.
 	 */
-	PowerController(FPGA* fpga, ExpansionFPGA* expansionFPGA, M1M3SSPublisher* publisher, SafetyController* safetyController);
+	PowerController(M1M3SSPublisher* publisher, SafetyController* safetyController);
 
 	/*!
 	 * Processes currently available power data and publish it.

--- a/Controller/src/LSST/M1M3/SS/Publisher/M1M3SSPublisher.cpp
+++ b/Controller/src/LSST/M1M3/SS/Publisher/M1M3SSPublisher.cpp
@@ -540,8 +540,7 @@ void M1M3SSPublisher::logErrorCode() {
 }
 
 void M1M3SSPublisher::tryLogErrorCode() {
-	if (this->eventErrorCode.errorCode != this->previousEventErrorCode.errorCode ||
-		this->eventErrorCode.detailedErrorCode != this->previousEventErrorCode.detailedErrorCode) {
+	if (this->eventErrorCode.errorCode != this->previousEventErrorCode.errorCode) {
 		this->logErrorCode();
 	}
 }

--- a/Controller/src/LSST/M1M3/SS/SafetyController/SafetyController.cpp
+++ b/Controller/src/LSST/M1M3/SS/SafetyController/SafetyController.cpp
@@ -20,9 +20,7 @@ SafetyController::SafetyController(M1M3SSPublisher* publisher, SafetyControllerS
 	this->publisher = publisher;
 	this->safetyControllerSettings = safetyControllerSettings;
 	this->errorCodeData = this->publisher->getEventErrorCode();
-	this->errorCodeData->timestamp = this->publisher->getTimestamp();
 	this->errorCodeData->errorCode = FaultCodes::NoFault;
-	this->errorCodeData->detailedErrorCode = FaultCodes::NoFault;
 	this->publisher->logErrorCode();
 	for(int i = 0; i < this->safetyControllerSettings->ILC.CommunicationTimeoutPeriod; ++i) {
 		this->ilcCommunicationTimeoutData.push_back(0);
@@ -46,8 +44,6 @@ SafetyController::SafetyController(M1M3SSPublisher* publisher, SafetyControllerS
 
 void SafetyController::clearErrorCode() {
 	Log.Info("SafetyController: clearErrorCode()");
-	this->errorCodeData->timestamp = this->publisher->getTimestamp();
-	this->errorCodeData->detailedErrorCode= FaultCodes::NoFault;
 	this->errorCodeData->errorCode= FaultCodes::NoFault;
 	this->publisher->logErrorCode();
 }
@@ -165,22 +161,10 @@ void SafetyController::hardpointActuatorAirPressure(int actuatorDataIndex, bool 
 }
 
 States::Type SafetyController::checkSafety(States::Type preferredNextState) {
-	if (this->errorCodeData->detailedErrorCode != FaultCodes::NoFault) {
-		this->publisher->logErrorCode();
-		this->errorCodeData->detailedErrorCode= FaultCodes::NoFault;
-		this->errorCodeData->errorCode= FaultCodes::NoFault;
-		return States::LoweringFaultState;
-	}
 	return preferredNextState;
 }
 
 void SafetyController::updateOverride(FaultCodes::Type faultCode, bool enabledFlag, bool conditionFlag) {
-	bool faultConditionExists = enabledFlag && conditionFlag;
-	if (faultConditionExists && this->errorCodeData->detailedErrorCode == FaultCodes::NoFault) {
-		this->errorCodeData->timestamp = this->publisher->getTimestamp();
-		this->errorCodeData->detailedErrorCode = (int32_t)faultCode;
-		this->errorCodeData->errorCode = (int32_t)(((int64_t)faultCode) >> 32);
-	}
 }
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/Settings/ForceActuatorApplicationSettings.cpp
+++ b/Controller/src/LSST/M1M3/SS/Settings/ForceActuatorApplicationSettings.cpp
@@ -22,7 +22,11 @@ namespace SS {
 
 void ForceActuatorApplicationSettings::load(const std::string &filename) {
 	pugi::xml_document doc;
-	doc.load_file(filename.c_str());
+        pugi::xml_parse_result res = doc.load_file(filename.c_str());
+        if (res.status != pugi::xml_parse_status::status_ok) {
+            Log.Error("ForceActuatorApplicationSettings::load loading %s: %s", filename.c_str(), res.description());
+            return;
+        }
 	this->loadForceActuatorTable(doc.select_node("//ForceActuatorApplicationSettings/ForceActuatorTablePath").node().child_value());
 	this->XIndexToZIndex.clear();
 	this->YIndexToZIndex.clear();
@@ -75,6 +79,10 @@ void ForceActuatorApplicationSettings::loadForceActuatorTable(const std::string 
 	std::ifstream inputStream(filename.c_str());
 	std::string lineText;
 	int32_t lineNumber = 0;
+        if (!inputStream.good()) {
+            Log.Error("Cannot read %s", filename.c_str());
+            exit(2);
+        }
 	while(std::getline(inputStream, lineText)) {
 		boost::trim_right(lineText);
 		if (lineNumber != 0 && !lineText.empty()) {

--- a/Controller/src/LSST/M1M3/SS/Settings/SettingReader.cpp
+++ b/Controller/src/LSST/M1M3/SS/Settings/SettingReader.cpp
@@ -9,149 +9,162 @@
 #include <boost/tokenizer.hpp>
 #include <Log.h>
 
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
 SettingReader::SettingReader(std::string basePath, std::string setsPath) {
-	Log.Debug("SettingReader: SettingReader(\"%s\", \"%s\")", basePath.c_str(), setsPath.c_str());
-	this->basePath = basePath;
-	this->setsPath = setsPath;
-	this->currentSet = "";
-	this->currentVersion = "";
+    Log.Debug("SettingReader: SettingReader(\"%s\", \"%s\")", basePath.c_str(), setsPath.c_str());
+    struct stat dirstat;
+    if (stat(basePath.c_str(), &dirstat)) {
+        Log.Fatal("Directory %s doesn't exist: %s", basePath.c_str(), strerror(errno));
+        exit(2);
+    }
+
+    this->basePath = basePath;
+    this->setsPath = setsPath;
+    this->currentSet = "";
+    this->currentVersion = "";
 }
 
 void SettingReader::configure(std::string settingsToApply) {
-	Log.Debug("SettingReader: configure(\"%s\")", settingsToApply.c_str());
-	if (settingsToApply.find(',') != std::string::npos) {
-		typedef boost::tokenizer< boost::escaped_list_separator<char> > tokenizer;
-		tokenizer tokenize(settingsToApply);
-		tokenizer::iterator token = tokenize.begin();
-		this->currentSet = *token;
-		++token;
-		this->currentVersion = *token;
-	}
-	else {
-		AliasApplicationSettings* aliasApplicationSettings = this->loadAliasApplicationSettings();
-		for(uint32_t i = 0; i != aliasApplicationSettings->Aliases.size(); ++i) {
-			Alias alias = aliasApplicationSettings->Aliases[i];
-			if (alias.Name.compare(settingsToApply) == 0) {
-				this->currentSet = alias.Set;
-				this->currentVersion = alias.Version;
-				break;
-			}
-		}
-	}
+    Log.Debug("SettingReader: configure(\"%s\")", settingsToApply.c_str());
+    if (settingsToApply.find(',') != std::string::npos) {
+        typedef boost::tokenizer<boost::escaped_list_separator<char> > tokenizer;
+        tokenizer tokenize(settingsToApply);
+        tokenizer::iterator token = tokenize.begin();
+        this->currentSet = *token;
+        ++token;
+        this->currentVersion = *token;
+    } else {
+        AliasApplicationSettings* aliasApplicationSettings = this->loadAliasApplicationSettings();
+        for (uint32_t i = 0; i != aliasApplicationSettings->Aliases.size(); ++i) {
+            Alias alias = aliasApplicationSettings->Aliases[i];
+            if (alias.Name.compare(settingsToApply) == 0) {
+                this->currentSet = alias.Set;
+                this->currentVersion = alias.Version;
+                break;
+            }
+        }
+    }
 }
 
 AliasApplicationSettings* SettingReader::loadAliasApplicationSettings() {
-	Log.Debug("SettingReader: loadAliasApplicationSettings()");
-	this->aliasApplicationSettings.load(this->getBasePath("AliasApplicationSettings.xml").c_str());
-	return &this->aliasApplicationSettings;
+    Log.Debug("SettingReader: loadAliasApplicationSettings()");
+    this->aliasApplicationSettings.load(this->getBasePath("AliasApplicationSettings.xml").c_str());
+    return &this->aliasApplicationSettings;
 }
 
 ForceActuatorApplicationSettings* SettingReader::loadForceActuatorApplicationSettings() {
-	Log.Debug("SettingReader: loadForceActuatorApplicationSettings()");
-	this->forceActuatorApplicationSettings.load(this->getBasePath("ForceActuatorApplicationSettings.xml").c_str());
-	return &this->forceActuatorApplicationSettings;
+    Log.Debug("SettingReader: loadForceActuatorApplicationSettings()");
+    this->forceActuatorApplicationSettings.load(
+            this->getBasePath("ForceActuatorApplicationSettings.xml").c_str());
+    return &this->forceActuatorApplicationSettings;
 }
 
 ForceActuatorSettings* SettingReader::loadForceActuatorSettings() {
-	Log.Debug("SettingReader: loadForceActuatorSettings()");
-	this->forceActuatorSettings.load(this->getSetPath("ForceActuatorSettings.xml").c_str());
-	return &this->forceActuatorSettings;
+    Log.Debug("SettingReader: loadForceActuatorSettings()");
+    this->forceActuatorSettings.load(this->getSetPath("ForceActuatorSettings.xml").c_str());
+    return &this->forceActuatorSettings;
 }
 
 HardpointActuatorApplicationSettings* SettingReader::loadHardpointActuatorApplicationSettings() {
-	Log.Debug("SettingReader: loadHardpointActuatorApplicationSettings()");
-	this->hardpointActuatorApplicationSettings.load(this->getBasePath("HardpointActuatorApplicationSettings.xml").c_str());
-	return &this->hardpointActuatorApplicationSettings;
+    Log.Debug("SettingReader: loadHardpointActuatorApplicationSettings()");
+    this->hardpointActuatorApplicationSettings.load(
+            this->getBasePath("HardpointActuatorApplicationSettings.xml").c_str());
+    return &this->hardpointActuatorApplicationSettings;
 }
 
 HardpointActuatorSettings* SettingReader::loadHardpointActuatorSettings() {
-	Log.Debug("SettingReader: loadHardpointActuatorSettings()");
-	this->hardpointActuatorSettings.load(this->getSetPath("HardpointActuatorSettings.xml").c_str());
-	return &this->hardpointActuatorSettings;
+    Log.Debug("SettingReader: loadHardpointActuatorSettings()");
+    this->hardpointActuatorSettings.load(this->getSetPath("HardpointActuatorSettings.xml").c_str());
+    return &this->hardpointActuatorSettings;
 }
 
 ILCApplicationSettings* SettingReader::loadILCApplicationSettings() {
-	Log.Debug("SettingReader: loadILCApplicationSettings()");
-	this->ilcApplicationSettings.load(this->getBasePath("ILCApplicationSettings.xml").c_str());
-	return &this->ilcApplicationSettings;
+    Log.Debug("SettingReader: loadILCApplicationSettings()");
+    this->ilcApplicationSettings.load(this->getBasePath("ILCApplicationSettings.xml").c_str());
+    return &this->ilcApplicationSettings;
 }
 
 RecommendedApplicationSettings* SettingReader::loadRecommendedApplicationSettings() {
-	Log.Debug("SettingReader: loadRecommendedApplicationSettings()");
-	this->recommendedApplicationSettings.load(this->getBasePath("RecommendedApplicationSettings.xml").c_str());
-	return &this->recommendedApplicationSettings;
+    Log.Debug("SettingReader: loadRecommendedApplicationSettings()");
+    this->recommendedApplicationSettings.load(
+            this->getBasePath("RecommendedApplicationSettings.xml").c_str());
+    return &this->recommendedApplicationSettings;
 }
 
 SafetyControllerSettings* SettingReader::loadSafetyControllerSettings() {
-	Log.Debug("SettingReader: loadSafetyControllerSettings()");
-	this->safetyControllerSettings.load(this->getSetPath("SafetyControllerSettings.xml").c_str());
-	return &this->safetyControllerSettings;
+    Log.Debug("SettingReader: loadSafetyControllerSettings()");
+    this->safetyControllerSettings.load(this->getSetPath("SafetyControllerSettings.xml").c_str());
+    return &this->safetyControllerSettings;
 }
 
 PositionControllerSettings* SettingReader::loadPositionControllerSettings() {
-	Log.Debug("SettingReader: loadPositionControllerSettings()");
-	this->positionControllerSettings.load(this->getSetPath("PositionControllerSettings.xml").c_str());
-	return &this->positionControllerSettings;
+    Log.Debug("SettingReader: loadPositionControllerSettings()");
+    this->positionControllerSettings.load(this->getSetPath("PositionControllerSettings.xml").c_str());
+    return &this->positionControllerSettings;
 }
 
 AccelerometerSettings* SettingReader::loadAccelerometerSettings() {
-	Log.Debug("SettingReader: loadAccelerometerSettings()");
-	this->accelerometerSettings.load(this->getSetPath("AccelerometerSettings.xml").c_str());
-	return &this->accelerometerSettings;
+    Log.Debug("SettingReader: loadAccelerometerSettings()");
+    this->accelerometerSettings.load(this->getSetPath("AccelerometerSettings.xml").c_str());
+    return &this->accelerometerSettings;
 }
 
 DisplacementSensorSettings* SettingReader::loadDisplacementSensorSettings() {
-	Log.Debug("SettingReader: loadDisplacementSensorSettings()");
-	this->displacementSensorSettings.load(this->getSetPath("DisplacementSensorSettings.xml").c_str());
-	return &this->displacementSensorSettings;
+    Log.Debug("SettingReader: loadDisplacementSensorSettings()");
+    this->displacementSensorSettings.load(this->getSetPath("DisplacementSensorSettings.xml").c_str());
+    return &this->displacementSensorSettings;
 }
 
 HardpointMonitorApplicationSettings* SettingReader::loadHardpointMonitorApplicationSettings() {
-	Log.Debug("SettingReader: loadHardpointMonitorApplicationSettings()");
-	this->hardpointMonitorApplicationSettings.load(this->getBasePath("HardpointMonitorApplicationSettings.xml").c_str());
-	return &this->hardpointMonitorApplicationSettings;
+    Log.Debug("SettingReader: loadHardpointMonitorApplicationSettings()");
+    this->hardpointMonitorApplicationSettings.load(
+            this->getBasePath("HardpointMonitorApplicationSettings.xml").c_str());
+    return &this->hardpointMonitorApplicationSettings;
 }
 
 InterlockApplicationSettings* SettingReader::loadInterlockApplicationSettings() {
-	Log.Debug("SettingReader: loadInterlockApplicationSettings()");
-	this->interlockApplicationSettings.load(this->getBasePath("InterlockApplicationSettings.xml").c_str());
-	return &this->interlockApplicationSettings;
+    Log.Debug("SettingReader: loadInterlockApplicationSettings()");
+    this->interlockApplicationSettings.load(this->getBasePath("InterlockApplicationSettings.xml").c_str());
+    return &this->interlockApplicationSettings;
 }
 
 GyroSettings* SettingReader::loadGyroSettings() {
-	Log.Debug("SettingReader: loadGyroSettings()");
-	this->gyroSettings.load(this->getSetPath("GyroSettings.xml").c_str());
-	return &this->gyroSettings;
+    Log.Debug("SettingReader: loadGyroSettings()");
+    this->gyroSettings.load(this->getSetPath("GyroSettings.xml").c_str());
+    return &this->gyroSettings;
 }
 
 ExpansionFPGAApplicationSettings* SettingReader::loadExpansionFPGAApplicationSettings() {
-	Log.Debug("SettingReader: loadExpansionFPGAApplicationSettings()");
-	this->expansionFPGAApplicationSettings.load(this->getBasePath("ExpansionFPGAApplicationSettings.xml").c_str());
-	return &this->expansionFPGAApplicationSettings;
+    Log.Debug("SettingReader: loadExpansionFPGAApplicationSettings()");
+    this->expansionFPGAApplicationSettings.load(
+            this->getBasePath("ExpansionFPGAApplicationSettings.xml").c_str());
+    return &this->expansionFPGAApplicationSettings;
 }
 
 PIDSettings* SettingReader::loadPIDSettings() {
-	Log.Debug("SettingReader: loadPIDSettings()");
-	this->pidSettings.load(this->getSetPath("PIDSettings.xml"));
-	return &this->pidSettings;
+    Log.Debug("SettingReader: loadPIDSettings()");
+    this->pidSettings.load(this->getSetPath("PIDSettings.xml"));
+    return &this->pidSettings;
 }
 
 InclinometerSettings* SettingReader::loadInclinometerSettings() {
-	Log.Debug("SettingReader: loadInclinometerSettings()");
-	this->inclinometerSettings.load(this->getSetPath("InclinometerSettings.xml"));
-	return &this->inclinometerSettings;
+    Log.Debug("SettingReader: loadInclinometerSettings()");
+    this->inclinometerSettings.load(this->getSetPath("InclinometerSettings.xml"));
+    return &this->inclinometerSettings;
 }
 
-std::string SettingReader::getBasePath(std::string file) {
-	return this->basePath + file;
-}
+std::string SettingReader::getBasePath(std::string file) { return this->basePath + file; }
 
 std::string SettingReader::getSetPath(std::string file) {
-	return this->setsPath + this->currentSet + "/" + this->currentVersion + "/" + file;
+    return this->setsPath + this->currentSet + "/" + this->currentVersion + "/" + file;
 }
 
 } /* namespace SS */

--- a/Controller/src/LSST/M1M3/SS/Settings/SettingReader.h
+++ b/Controller/src/LSST/M1M3/SS/Settings/SettingReader.h
@@ -1,10 +1,3 @@
-/*
- * SettingReader.h
- *
- *  Created on: Oct 3, 2017
- *      Author: ccontaxis
- */
-
 #ifndef SETTINGREADER_H_
 #define SETTINGREADER_H_
 
@@ -31,6 +24,9 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Reads M1M3 support system configuration.
+ */
 class SettingReader {
 private:
 	AliasApplicationSettings aliasApplicationSettings;
@@ -57,6 +53,13 @@ private:
 	std::string currentVersion;
 
 public:
+        /**
+         * Construct new SettingReader. Verifies that basePath and setsPath
+         * directories exists and are readable, log and exit when not.
+         *
+         * @param basePath
+         * @param setsPath
+         */
 	SettingReader(std::string basePath, std::string setsPath);
 
 	void configure(std::string settingsToApply);

--- a/Controller/src/LSST/M1M3/SS/States/DisabledState.cpp
+++ b/Controller/src/LSST/M1M3/SS/States/DisabledState.cpp
@@ -37,7 +37,7 @@ States::Type DisabledState::update(UpdateCommand* command, Model* model) {
 	ilc->triggerModbus();
 	model->getDigitalInputOutput()->tryToggleHeartbeat();
 	usleep(1000);
-	model->getFPGA()->pullTelemetry();
+        IFPGA::get().pullTelemetry();
 	model->getAccelerometer()->processData();
 	model->getDigitalInputOutput()->processData();
 	model->getDisplacement()->processData();

--- a/Controller/src/LSST/M1M3/SS/States/EnabledState.cpp
+++ b/Controller/src/LSST/M1M3/SS/States/EnabledState.cpp
@@ -40,7 +40,7 @@ States::Type EnabledState::update(UpdateCommand* command, Model* model) {
 	ilc->triggerModbus();
 	model->getDigitalInputOutput()->tryToggleHeartbeat();
 	usleep(1000);
-	model->getFPGA()->pullTelemetry();
+        IFPGA::get().pullTelemetry();
 	model->getAccelerometer()->processData();
 	model->getDigitalInputOutput()->processData();
 	model->getDisplacement()->processData();
@@ -65,7 +65,7 @@ States::Type EnabledState::update(UpdateCommand* command, Model* model) {
 
 States::Type EnabledState::storeTMAAzimuthSample(TMAAzimuthSampleCommand* command, Model* model) {
 	Log.Trace("EnabledState: storeTMAAzimuthSample()");
-	model->getForceController()->updateAzimuthForces((float)command->getData()->Azimuth_Angle_Actual);
+	model->getForceController()->updateAzimuthForces((float)command->getData()->position);
 	return model->getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/Controller/src/LSST/M1M3/SS/States/FaultState.cpp
+++ b/Controller/src/LSST/M1M3/SS/States/FaultState.cpp
@@ -36,7 +36,7 @@ States::Type FaultState::update(UpdateCommand* command, Model* model) {
 	ilc->triggerModbus();
 	model->getDigitalInputOutput()->tryToggleHeartbeat();
 	usleep(1000);
-	model->getFPGA()->pullTelemetry();
+        IFPGA::get().pullTelemetry();
 	model->getAccelerometer()->processData();
 	model->getDigitalInputOutput()->processData();
 	model->getDisplacement()->processData();

--- a/Controller/src/LSST/M1M3/SS/Subscriber/M1M3SSSubscriber.cpp
+++ b/Controller/src/LSST/M1M3/SS/Subscriber/M1M3SSSubscriber.cpp
@@ -403,18 +403,18 @@ Command* M1M3SSSubscriber::tryAcceptCommandModbusTransmit() {
 }
 
 Command* M1M3SSSubscriber::tryGetSampleTMAAzimuth() {
-	int32_t result = this->mtMountSAL->getSample_Az(&this->tmaAzimuth);
+/*	int32_t result = this->mtMountSAL->getSample_Az(&this->tmaAzimuth);
 	if (result == 0) {
 		return this->commandFactory->create(Commands::TMAAzimuthSampleCommand, &this->tmaAzimuth, 0);
-	}
+	}*/
 	return 0;
 }
 
 Command* M1M3SSSubscriber::tryGetSampleTMAElevation() {
-	int32_t result = this->mtMountSAL->getSample_Alt(&this->tmaElevation);
+/*	int32_t result = this->mtMountSAL->getSample_Alt(&this->tmaElevation);
 	if (result == 0) {
 		return this->commandFactory->create(Commands::TMAElevationSampleCommand, &this->tmaElevation, 0);
-	}
+	}*/
 	return 0;
 }
 

--- a/Controller/src/LSST/M1M3/SS/Threads/OuterLoopClockThread.h
+++ b/Controller/src/LSST/M1M3/SS/Threads/OuterLoopClockThread.h
@@ -29,14 +29,13 @@ class OuterLoopClockThread: public IThread {
 private:
 	CommandFactory* commandFactory;
 	Controller* controller;
-	FPGA* fpga;
 	M1M3SSPublisher* publisher;
 	uint16_t timestampUpdateBuffer[5];
 	bool keepRunning;
 	pthread_mutex_t updateMutex;
 
 public:
-	OuterLoopClockThread(CommandFactory* commandFactory, Controller* controller, FPGA* fpga, M1M3SSPublisher* publisher);
+	OuterLoopClockThread(CommandFactory* commandFactory, Controller* controller, M1M3SSPublisher* publisher);
 	~OuterLoopClockThread();
 
 	void run();

--- a/Controller/src/LSST/M1M3/SS/Threads/PPSThread.cpp
+++ b/Controller/src/LSST/M1M3/SS/Threads/PPSThread.cpp
@@ -16,8 +16,7 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-PPSThread::PPSThread(FPGA* fpga, M1M3SSPublisher* publisher) {
-	this->fpga = fpga;
+PPSThread::PPSThread(M1M3SSPublisher* publisher) {
 	this->publisher = publisher;
 	this->keepRunning = true;
 }
@@ -25,11 +24,11 @@ PPSThread::PPSThread(FPGA* fpga, M1M3SSPublisher* publisher) {
 void PPSThread::run() {
 	Log.Info("PPSThread: Start");
 	while(this->keepRunning) {
-		if (this->fpga->waitForPPS(2500) == 0) {
-			this->fpga->ackPPS();
+		if (IFPGA::get().waitForPPS(2500) == 0) {
+			IFPGA::get().ackPPS();
 			uint64_t timestamp = Timestamp::toFPGA(this->publisher->getTimestamp());
 			if (this->keepRunning) {
-				this->fpga->writeTimestampFIFO(timestamp);
+				IFPGA::get().writeTimestampFIFO(timestamp);
 			}
 		}
 		else {

--- a/Controller/src/LSST/M1M3/SS/Threads/PPSThread.h
+++ b/Controller/src/LSST/M1M3/SS/Threads/PPSThread.h
@@ -20,13 +20,12 @@ class M1M3SSPublisher;
 
 class PPSThread: public IThread {
 private:
-	FPGA* fpga;
 	M1M3SSPublisher* publisher;
 	uint16_t timestampUpdateBuffer[5];
 	bool keepRunning;
 
 public:
-	PPSThread(FPGA* fpga, M1M3SSPublisher* publisher);
+	PPSThread(M1M3SSPublisher* publisher);
 
 	void run();
 	void stop();

--- a/Controller/src/ts_M1M3Support.cpp
+++ b/Controller/src/ts_M1M3Support.cpp
@@ -1,39 +1,34 @@
-//============================================================================
-// Name        : ts_M1M3Support.cpp
-// Author      : LSST
-// Version     :
-// Copyright   : LSST
-// Description : Hello World in C++, Ansi-style
-//============================================================================
-
-#include <iostream>
-#include <pthread.h>
 #include <CommandFactory.h>
-#include <M1M3SSSubscriber.h>
-#include <M1M3SSPublisher.h>
-#include <StaticStateFactory.h>
-#include <Model.h>
+#include <CommandTypes.h>
 #include <Context.h>
 #include <Controller.h>
-#include <SubscriberThread.h>
 #include <ControllerThread.h>
+#include <DigitalInputOutput.h>
+#include <IExpansionFPGA.h>
+#include <FPGAAddresses.h>
+#include <M1M3SSPublisher.h>
+#include <M1M3SSSubscriber.h>
+#include <Model.h>
 #include <OuterLoopClockThread.h>
-#include <FPGA.h>
-#include <CommandTypes.h>
-#include <SettingReader.h>
+#include <PPSThread.h>
 #include <SAL_MTM1M3.h>
 #include <SAL_MTMount.h>
-#include <Timestamp.h>
-#include <FPGAAddresses.h>
 #include <SafetyController.h>
-#include <DigitalInputOutput.h>
+#include <SettingReader.h>
+#include <StaticStateFactory.h>
+#include <SubscriberThread.h>
+#include <Timestamp.h>
+#include <pthread.h>
 #include <cstring>
-#include <ExpansionFPGA.h>
-#include <PPSThread.h>
+#include <iostream>
+
+#ifdef SIMULATOR
+#include <SimulatedFPGA.h>
+#else
+#include <FPGA.h>
+#endif
 
 #include <Log.h>
-
-#define SIMULATOR 1
 
 using namespace std;
 using namespace LSST::M1M3::SS;
@@ -43,194 +38,191 @@ void* runThread(void* data);
 LSST::M1M3::SS::Logger Log;
 
 int main() {
-	Log.SetLevel(Levels::Info);
-	Log.Info("Main: Creating setting reader");
-	SettingReader settingReader = SettingReader("/usr/ts_M1M3Support/SettingFiles/Base/", "/usr/ts_M1M3Support/SettingFiles/Sets/");
-	Log.Info("Main: Initializing M1M3 SAL");
-	SAL_MTM1M3 m1m3SAL = SAL_MTM1M3();
-	m1m3SAL.setDebugLevel(0);
-	Log.Info("Main: Initializing MTMount SAL");
-	SAL_MTMount mtMountSAL = SAL_MTMount();
-	Log.Info("Main: Creating publisher");
-	M1M3SSPublisher publisher = M1M3SSPublisher(&m1m3SAL);
-	Log.Info("Main: Creating fpga");
-/* Add this back for simulator capable version
-	FPGA realFPGA = FPGA();
-	SimulatedFPGA simulatedFPGA = SimulatedFPGA(&publisher, &tmaElevation, &tmaAzimuth, settingReader.loadForceActuatorApplicationSettings());
-	IFPGA* fpga;
-	if (SIMULATOR == 0) {
-		Log.Info("Main: Creating FPGA");
-		fpga = &realFPGA;
-	}
-	else {
-		Log.Info("Main: Creating simulated FPGA");
-		fpga = &simulatedFPGA;
-	}
- */
-	FPGA fpga = FPGA();
-	if (fpga.isErrorCode(fpga.initialize())) {
-		Log.Fatal("Main: Error initializing FPGA");
-		mtMountSAL.salShutdown();
-		m1m3SAL.salShutdown();
-		return -1;
-	}
-	if (fpga.isErrorCode(fpga.open())) {
-		Log.Fatal("Main: Error opening FPGA");
-		fpga.finalize();
-		mtMountSAL.salShutdown();
-		m1m3SAL.salShutdown();
-		return -1;
-	}
-	Log.Info("Main: Load expansion FPGA application settings");
-	ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings = settingReader.loadExpansionFPGAApplicationSettings();
-	Log.Info("Main: Create expansion FPGA");
-	ExpansionFPGA expansionFPGA = ExpansionFPGA(expansionFPGAApplicationSettings);
-	if (expansionFPGA.isErrorCode(expansionFPGA.open())) {
-		Log.Fatal("Main: Error opening expansion FPGA");
-		fpga.close();
-		fpga.finalize();
-		mtMountSAL.salShutdown();
-		m1m3SAL.salShutdown();
-		return -1;
-	}
-	Log.Info("Main: Creating state factory");
-	StaticStateFactory stateFactory = StaticStateFactory(&publisher);
-	Log.Info("Main: Load interlock application settings");
-	InterlockApplicationSettings* interlockApplicationSettings = settingReader.loadInterlockApplicationSettings();
-	Log.Info("Main: Creating digital input output");
-	DigitalInputOutput digitalInputOutput = DigitalInputOutput(interlockApplicationSettings, &fpga, &publisher);
-	Log.Info("Main: Creating model");
-	Model model = Model(&settingReader, &publisher, &fpga, &expansionFPGA, &digitalInputOutput);
-	Log.Info("Main: Creating context");
-	Context context = Context(&stateFactory, &model);
-	Log.Info("Main: Creating command factory");
-	CommandFactory commandFactory = CommandFactory(&publisher, &context);
-	Log.Info("Main: Creating subscriber");
-	M1M3SSSubscriber subscriber = M1M3SSSubscriber(&m1m3SAL, &mtMountSAL, &commandFactory);
-	Log.Info("Main: Creating controller");
-	Controller controller = Controller(&commandFactory);
-	Log.Info("Main: Creating subscriber thread");
-	SubscriberThread subscriberThread = SubscriberThread(&subscriber, &controller, &publisher, &commandFactory);
-	Log.Info("Main: Creating controller thread");
-	ControllerThread controllerThread = ControllerThread(&controller);
-	Log.Info("Main: Creating outer loop clock thread");
-	OuterLoopClockThread outerLoopClockThread = OuterLoopClockThread(&commandFactory, &controller, &fpga, &publisher);
-	Log.Info("Main: Creating pps thread");
-	PPSThread ppsThread = PPSThread(&fpga, &publisher);
-	Log.Info("Main: Queuing boot command");
-	controller.enqueue(commandFactory.create(Commands::BootCommand));
+    Log.SetLevel(Levels::Info);
+    Log.Info("Main: Creating setting reader");
+    string basePath = "/home/petr/ts_m1m3support/Controller/SettingFiles/";
+    SettingReader settingReader = SettingReader(basePath + "/Base/", basePath + "/Sets/");
+    Log.Info("Main: Initializing M1M3 SAL");
+    SAL_MTM1M3 m1m3SAL = SAL_MTM1M3();
+    m1m3SAL.setDebugLevel(0);
+    Log.Info("Main: Initializing MTMount SAL");
+    SAL_MTMount mtMountSAL = SAL_MTMount();
+    Log.Info("Main: Creating publisher");
+    M1M3SSPublisher publisher = M1M3SSPublisher(&m1m3SAL);
+    Log.Info("Main: Creating fpga");
 
-	pthread_t subscriberThreadId;
-	pthread_t controllerThreadId;
-	pthread_t outerLoopClockThreadId;
-	pthread_t ppsThreadId;
-	pthread_attr_t threadAttribute;
-	pthread_attr_init(&threadAttribute);
-	pthread_attr_setdetachstate(&threadAttribute, PTHREAD_CREATE_JOINABLE);
+    IFPGA* fpga = &IFPGA::get();
+#ifdef SIMULATOR
+    ((SimulatedFPGA*)fpga)->setPublisher(&publisher);
+    ((SimulatedFPGA*)fpga)
+            ->setForceActuatorApplicationSettings(settingReader.loadForceActuatorApplicationSettings());
+#endif
 
-	void* status;
-	Log.Info("Main: Starting pps thread");
-	int rc = pthread_create(&ppsThreadId, &threadAttribute, runThread, (void*)(&ppsThread));
-	usleep(1500000);
-	if (!rc) {
-		Log.Info("Main: Starting subscriber thread");
-		int rc = pthread_create(&subscriberThreadId, &threadAttribute, runThread, (void*)(&subscriberThread));
-		if (!rc) {
-			Log.Info("Main: Starting controller thread");
-			rc = pthread_create(&controllerThreadId, &threadAttribute, runThread, (void*)(&controllerThread));
-			if (!rc) {
-				Log.Info("Main: Starting outer loop clock thread");
-				rc = pthread_create(&outerLoopClockThreadId, &threadAttribute, runThread, (void*)(&outerLoopClockThread));
-				if (!rc) {
-					Log.Info("Main: Waiting for shutdown");
-					model.waitForShutdown();
-					Log.Info("Main: Shutdown received");
-					Log.Info("Main: Stopping pps thread");
-					ppsThread.stop();
-					Log.Info("Main: Stopping subscriber thread");
-					subscriberThread.stop();
-					Log.Info("Main: Stopping controller thread");
-					controllerThread.stop();
-					Log.Info("Main: Stopping outer loop clock thread");
-					outerLoopClockThread.stop();
-					usleep(100000);
-					controller.clear();
-					Log.Info("Main: Joining pps thread");
-					pthread_join(ppsThreadId, &status);
-					Log.Info("Main: Joining subscriber thread");
-					pthread_join(subscriberThreadId, &status);
-					Log.Info("Main: Joining controller thread");
-					pthread_join(controllerThreadId, &status);
-					Log.Info("Main: Joining outer loop clock thread");
-					pthread_join(outerLoopClockThreadId, &status);
-				}
-				else {
-					Log.Fatal("Main: Failed to start outer loop clock thread");
-					Log.Info("Main: Stopping pps thread");
-					ppsThread.stop();
-					Log.Info("Main: Stopping subscriber thread");
-					subscriberThread.stop();
-					Log.Info("Main: Stopping controller thread");
-					controllerThread.stop();
-					Log.Info("Main: Joining pps thread");
-					pthread_join(ppsThreadId, &status);
-					Log.Info("Main: Joining subscriber thread");
-					pthread_join(subscriberThreadId, &status);
-					Log.Info("Main: Joining controller thread");
-					pthread_join(controllerThreadId, &status);
-				}
-			}
-			else {
-				Log.Fatal("Main: Failed to start controller thread");
-				Log.Info("Main: Stopping pps thread");
-				ppsThread.stop();
-				Log.Info("Main: Stopping subscriber thread");
-				subscriberThread.stop();
-				Log.Info("Main: Joining pps thread");
-				pthread_join(ppsThreadId, &status);
-				Log.Info("Main: Joining subscriber thread");
-				pthread_join(subscriberThreadId, &status);
-			}
-		}
-		else {
-			Log.Fatal("Main: Failed to start subscriber thread");
-			Log.Info("Main: Stopping pps thread");
-			ppsThread.stop();
-			Log.Info("Main: Joining pps thread");
-			pthread_join(ppsThreadId, &status);
-		}
-	}
-	else {
-		Log.Fatal("Main: Failed to start pps thread");
-	}
+    if (fpga->isErrorCode(fpga->initialize())) {
+        Log.Fatal("Main: Error initializing FPGA");
+        mtMountSAL.salShutdown();
+        m1m3SAL.salShutdown();
+        return -1;
+    }
+    if (fpga->isErrorCode(fpga->open())) {
+        Log.Fatal("Main: Error opening FPGA");
+        fpga->finalize();
+        mtMountSAL.salShutdown();
+        m1m3SAL.salShutdown();
+        return -1;
+    }
+    Log.Info("Main: Load expansion FPGA application settings");
+    ExpansionFPGAApplicationSettings* expansionFPGAApplicationSettings =
+            settingReader.loadExpansionFPGAApplicationSettings();
+    Log.Info("Main: Create expansion FPGA");
+    IExpansionFPGA* expansionFPGA = &IExpansionFPGA::get();
+    expansionFPGA->setExpansionFPGAApplicationSettings(expansionFPGAApplicationSettings);
+    if (expansionFPGA->isErrorCode(expansionFPGA->open())) {
+        Log.Fatal("Main: Error opening expansion FPGA");
+        fpga->close();
+        fpga->finalize();
+        mtMountSAL.salShutdown();
+        m1m3SAL.salShutdown();
+        return -1;
+    }
+    Log.Info("Main: Creating state factory");
+    StaticStateFactory stateFactory = StaticStateFactory(&publisher);
+    Log.Info("Main: Load interlock application settings");
+    InterlockApplicationSettings* interlockApplicationSettings =
+            settingReader.loadInterlockApplicationSettings();
+    Log.Info("Main: Creating digital input output");
+    DigitalInputOutput digitalInputOutput = DigitalInputOutput(interlockApplicationSettings, &publisher);
+    Log.Info("Main: Creating model");
+    Model model = Model(&settingReader, &publisher, &digitalInputOutput);
+    Log.Info("Main: Creating context");
+    Context context = Context(&stateFactory, &model);
+    Log.Info("Main: Creating command factory");
+    CommandFactory commandFactory = CommandFactory(&publisher, &context);
+    Log.Info("Main: Creating subscriber");
+    M1M3SSSubscriber subscriber = M1M3SSSubscriber(&m1m3SAL, &mtMountSAL, &commandFactory);
+    Log.Info("Main: Creating controller");
+    Controller controller = Controller(&commandFactory);
+    Log.Info("Main: Creating subscriber thread");
+    SubscriberThread subscriberThread =
+            SubscriberThread(&subscriber, &controller, &publisher, &commandFactory);
+    Log.Info("Main: Creating controller thread");
+    ControllerThread controllerThread = ControllerThread(&controller);
+    Log.Info("Main: Creating outer loop clock thread");
+    OuterLoopClockThread outerLoopClockThread =
+            OuterLoopClockThread(&commandFactory, &controller, &publisher);
+    Log.Info("Main: Creating pps thread");
+    PPSThread ppsThread = PPSThread(&publisher);
+    Log.Info("Main: Queuing boot command");
+    controller.enqueue(commandFactory.create(Commands::BootCommand));
 
-	pthread_attr_destroy(&threadAttribute);
+    pthread_t subscriberThreadId;
+    pthread_t controllerThreadId;
+    pthread_t outerLoopClockThreadId;
+    pthread_t ppsThreadId;
+    pthread_attr_t threadAttribute;
+    pthread_attr_init(&threadAttribute);
+    pthread_attr_setdetachstate(&threadAttribute, PTHREAD_CREATE_JOINABLE);
 
-	if (expansionFPGA.isErrorCode(expansionFPGA.close())) {
-		Log.Error("Main: Error closing expansion FPGA");
-	}
+    void* status;
+    Log.Info("Main: Starting pps thread");
+    int rc = pthread_create(&ppsThreadId, &threadAttribute, runThread, (void*)(&ppsThread));
+    usleep(1500000);
+    if (!rc) {
+        Log.Info("Main: Starting subscriber thread");
+        int rc = pthread_create(&subscriberThreadId, &threadAttribute, runThread, (void*)(&subscriberThread));
+        if (!rc) {
+            Log.Info("Main: Starting controller thread");
+            rc = pthread_create(&controllerThreadId, &threadAttribute, runThread, (void*)(&controllerThread));
+            if (!rc) {
+                Log.Info("Main: Starting outer loop clock thread");
+                rc = pthread_create(&outerLoopClockThreadId, &threadAttribute, runThread,
+                                    (void*)(&outerLoopClockThread));
+                if (!rc) {
+                    Log.Info("Main: Waiting for shutdown");
+                    model.waitForShutdown();
+                    Log.Info("Main: Shutdown received");
+                    Log.Info("Main: Stopping pps thread");
+                    ppsThread.stop();
+                    Log.Info("Main: Stopping subscriber thread");
+                    subscriberThread.stop();
+                    Log.Info("Main: Stopping controller thread");
+                    controllerThread.stop();
+                    Log.Info("Main: Stopping outer loop clock thread");
+                    outerLoopClockThread.stop();
+                    usleep(100000);
+                    controller.clear();
+                    Log.Info("Main: Joining pps thread");
+                    pthread_join(ppsThreadId, &status);
+                    Log.Info("Main: Joining subscriber thread");
+                    pthread_join(subscriberThreadId, &status);
+                    Log.Info("Main: Joining controller thread");
+                    pthread_join(controllerThreadId, &status);
+                    Log.Info("Main: Joining outer loop clock thread");
+                    pthread_join(outerLoopClockThreadId, &status);
+                } else {
+                    Log.Fatal("Main: Failed to start outer loop clock thread");
+                    Log.Info("Main: Stopping pps thread");
+                    ppsThread.stop();
+                    Log.Info("Main: Stopping subscriber thread");
+                    subscriberThread.stop();
+                    Log.Info("Main: Stopping controller thread");
+                    controllerThread.stop();
+                    Log.Info("Main: Joining pps thread");
+                    pthread_join(ppsThreadId, &status);
+                    Log.Info("Main: Joining subscriber thread");
+                    pthread_join(subscriberThreadId, &status);
+                    Log.Info("Main: Joining controller thread");
+                    pthread_join(controllerThreadId, &status);
+                }
+            } else {
+                Log.Fatal("Main: Failed to start controller thread");
+                Log.Info("Main: Stopping pps thread");
+                ppsThread.stop();
+                Log.Info("Main: Stopping subscriber thread");
+                subscriberThread.stop();
+                Log.Info("Main: Joining pps thread");
+                pthread_join(ppsThreadId, &status);
+                Log.Info("Main: Joining subscriber thread");
+                pthread_join(subscriberThreadId, &status);
+            }
+        } else {
+            Log.Fatal("Main: Failed to start subscriber thread");
+            Log.Info("Main: Stopping pps thread");
+            ppsThread.stop();
+            Log.Info("Main: Joining pps thread");
+            pthread_join(ppsThreadId, &status);
+        }
+    } else {
+        Log.Fatal("Main: Failed to start pps thread");
+    }
 
-	if (fpga.isErrorCode(fpga.close())) {
-		Log.Error("Main: Error closing FPGA");
-	}
+    pthread_attr_destroy(&threadAttribute);
 
-	if (fpga.isErrorCode(fpga.finalize())) {
-		Log.Error("Main: Error finalizing FPGA");
-	}
+    if (expansionFPGA->isErrorCode(expansionFPGA->close())) {
+        Log.Error("Main: Error closing expansion FPGA");
+    }
 
-	Log.Info("Main: Shutting down MTMount SAL");
-	mtMountSAL.salShutdown();
+    if (fpga->isErrorCode(fpga->close())) {
+        Log.Error("Main: Error closing FPGA");
+    }
 
-	Log.Info("Main: Shutting down M1M3 SAL");
-	m1m3SAL.salShutdown();
+    if (fpga->isErrorCode(fpga->finalize())) {
+        Log.Error("Main: Error finalizing FPGA");
+    }
 
-	Log.Info("Main: Shutdown complete");
+    Log.Info("Main: Shutting down MTMount SAL");
+    mtMountSAL.salShutdown();
 
-	return 0;
+    Log.Info("Main: Shutting down M1M3 SAL");
+    m1m3SAL.salShutdown();
+
+    Log.Info("Main: Shutdown complete");
+
+    return 0;
 }
 
 void* runThread(void* data) {
-	IThread* thread = (IThread*)data;
-	thread->run();
-	return 0;
+    IThread* thread = (IThread*)data;
+    thread->run();
+    return 0;
 }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cd $BASE
 source ts_sal/setup.env
 cd ts_m1m3support/Controller/CentOS
 make clean
-make -DSIMULATOR
+make SIMULATOR=1
 ```
 
 ## Setting up the runtime environment


### PR DESCRIPTION
IFPGA and IExpansionFPGA are singleton. Static get method delivers
either simulated object, or object talking to real FPGA hardware. All
FPGA and ExpansionFPGA parameters are deleted and replaced by
acquisition of singleton, as needed. Fixes simulation code, so it runs.
Real FPGA code compiles. Reformat few source files using clang-formater (LSST standard).