### PR TITLE
DM-25202: Generate and uses C/CPP dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,11 +26,18 @@ node {
         dir("ts_Dockerfiles") {
             git branch: (BRANCH == "master" ? "master" : "develop"), url: 'https://github.com/lsst-ts/ts_Dockerfiles'
         }
+        sh '''
+          ls -l
+          ls -l ts_Dockerfiles
+        '''
     }
 
     stage('Cloning source')
     {
         git branch: BRANCH, url: 'https://github.com/lsst-ts/ts_m1m3support'
+        sh '''
+          ls -l
+        '''
     }
 
     stage('Building dev container')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,24 +17,25 @@ node {
 
     def M1M3sim
     def SAL_REPOS = "/home/saluser/repos"
+    def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
 
     stage('Cloning Dockerfile')
     {
         sh "printenv"
 
         dir("ts_Dockerfiles") {
-            git branch: "tickets/DM-25064", url: 'https://github.com/lsst-ts/ts_Dockerfiles'
+            git branch: (BRANCH == "master" ? "master" : "develop"), url: 'https://github.com/lsst-ts/ts_Dockerfiles'
         }
     }
 
     stage('Cloning source')
     {
-        git branch: ((env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME), url: 'https://github.com/lsst-ts/ts_m1m3support'
+        git branch: BRANCH, url: 'https://github.com/lsst-ts/ts_m1m3support'
     }
 
     stage('Building dev container')
     {
-        M1M3sim = docker.build("lsstts/mtm1m3_sim:${env.BRANCH_NAME}", "--target lsstts-cpp-dev ts_Dockerfiles/mtm1m3_sim")
+        M1M3sim = docker.build("lsstts/mtm1m3_sim:" + env.BRANCH_NAME.replace("/", "_"), "--target lsstts-cpp-dev ts_Dockerfiles/mtm1m3_sim")
     }
 
     stage("Running tests")
@@ -48,7 +49,6 @@ node {
                     export PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH
     
                     cd $WORKSPACE
-                    make clean
                     make SIMULATOR=1
                     make junit
                 '''

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,13 +2,19 @@ include ../Makefile.inc
 
 all: libM1M3SS.a
 
+.PHONY: DEPS clean
+
 C_SRCS = $(shell find LSST -name '*.c')
 CPP_SRCS = $(shell find LSST pugixml -name '*.cpp')
 
 OBJS = $(patsubst %.c,%.o,$(C_SRCS)) $(patsubst %.cpp,%.o,$(CPP_SRCS))
 
-C_DEPS = $(patsubst %.c,%.d,$(C_SRCS))
-CPP_DEPS = $(patsubst %.cpp,%.d,$(CPP_SRCS))
+C_DEPS = $(patsubst %.c,%.c.d,$(C_SRCS))
+CPP_DEPS = $(patsubst %.cpp,%.cpp.d,$(CPP_SRCS))
+
+ifneq ($(MAKECMDGOALS),clean)
+  -include ${C_DEPS} ${CPP_DEPS}
+endif
 
 M1M3_CPPFLAGS := -I. \
 	-I"LSST/M1M3/SS/DigitalInputOutput" \
@@ -53,10 +59,17 @@ clean:
 
 # file targets
 %.o: %.cpp
-	@echo '[CPP] $^'
-	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -c -fmessage-length=0 -o $@ $^
+	@echo '[CPP] $<'
+	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -c -fmessage-length=0 -o $@ $<
 
 %.o: %.c
-	@echo '[C  ] $^'
-	${co}$(C) -c -fmessage-length=0 -o $@ $^
+	@echo '[C  ] $<'
+	${co}$(C) -c -fmessage-length=0 -o $@ $<
 
+%.cpp.d: %.cpp
+	@echo '[DPP] $^'
+	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$*.o'
+
+%.c.d: %.c
+	@echo '[DEP] $^'
+	${co}$(C) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$*.o'

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,11 +8,11 @@ all: compile
 
 TEST_SRCS := $(shell ls test_*.cpp 2>/dev/null)
 BINARIES := $(patsubst %.cpp,%,$(TEST_SRCS))
-DEPS := $(patsubst %.cpp,%.d,$(TEST_SRCS))
+DEPS := $(patsubst %.cpp,%.cpp.d,$(TEST_SRCS))
 OBJS := $(patsubst %.cpp,%.o,$(TEST_SRCS))
 JUNIT_FILES := $(shell ls *.xml 2>/dev/null)
 
-ifeq (0, $(words $(findstring $(MAKECMDGOALS), "clean")))
+ifneq ($(MAKECMDGOALS),clean)
     -include $(DEPS)
 endif
 
@@ -65,10 +65,10 @@ clean:
 ../src/libM1M3SS.a: FORCE
 	@$(MAKE) -C ../src libM1M3SS.a SIMULATOR=1
 
-%.d: %.cpp
+%.cpp.d: %.cpp
 	@echo '[DEP] $<'
-	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -MM -MT '$(patsubst %.cpp,%.o,$<)' $< -MF $@
+	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@
 
-%: %.cpp ../src/libM1M3SS.a %.d
+%: %.cpp ../src/libM1M3SS.a
 	@echo '[TPP] $<'
 	${co}$(CPP) -o $@ $(LIBS_FLAGS) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(LIBS) $(M1M3_CPPFLAGS) $< ../src/libM1M3SS.a


### PR DESCRIPTION
Dependency files are generated, listing all included files. Those are
used to trigger rebuilding of all source files including a changed .h.
Makes the "make clean" step irrelevant, speeding up builds.