### PR TITLE
DM-23954: throw NiError on NI-FPGA related failures

### DIFF
--- a/src/LSST/M1M3/SS/CommandFactory/CommandFactory.cpp
+++ b/src/LSST/M1M3/SS/CommandFactory/CommandFactory.cpp
@@ -28,7 +28,7 @@
 #include <DisableCommand.h>
 #include <StandbyCommand.h>
 #include <UpdateCommand.h>
-#include <ShutdownCommand.h>
+#include <ExitControlCommand.h>
 #include <TurnAirOnCommand.h>
 #include <TurnAirOffCommand.h>
 #include <ApplyOffsetForcesCommand.h>
@@ -96,8 +96,9 @@ Command* CommandFactory::create(Commands::Type commandType, void* data, int32_t 
             return new StandbyCommand(_context, _publisher, commandID, (MTM1M3_command_standbyC*)data);
         case Commands::UpdateCommand:
             return new UpdateCommand(_context, (pthread_mutex_t*)data);
-        case Commands::ShutdownCommand:
-            return new ShutdownCommand(_context, _publisher, commandID, (MTM1M3_command_shutdownC*)data);
+        case Commands::ExitControlCommand:
+            return new ExitControlCommand(_context, _publisher, commandID,
+                                          (MTM1M3_command_exitControlC*)data);
         case Commands::TurnAirOnCommand:
             return new TurnAirOnCommand(_context, _publisher, commandID, (MTM1M3_command_turnAirOnC*)data);
         case Commands::TurnAirOffCommand:

--- a/src/LSST/M1M3/SS/CommandFactory/CommandFactory.cpp
+++ b/src/LSST/M1M3/SS/CommandFactory/CommandFactory.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <CommandFactory.h>
-#include <BootCommand.h>
+#include <EnterControlCommand.h>
 #include <StartCommand.h>
 #include <EnableCommand.h>
 #include <DisableCommand.h>
@@ -84,8 +84,8 @@ CommandFactory::CommandFactory(M1M3SSPublisher* publisher, Context* context) {
 Command* CommandFactory::create(Commands::Type commandType, void* data, int32_t commandID) {
     spdlog::trace("CommandFactory: create({}, data, {})", commandType, commandID);
     switch (commandType) {
-        case Commands::BootCommand:
-            return new BootCommand(_context);
+        case Commands::EnterControlCommand:
+            return new EnterControlCommand(_context);
         case Commands::StartCommand:
             return new StartCommand(_context, _publisher, commandID, (MTM1M3_command_startC*)data);
         case Commands::EnableCommand:

--- a/src/LSST/M1M3/SS/CommandFactory/CommandTypes.h
+++ b/src/LSST/M1M3/SS/CommandFactory/CommandTypes.h
@@ -39,7 +39,7 @@ struct Commands {
         DisableCommand = 3,
         StandbyCommand = 4,
         UpdateCommand = 5,
-        ShutdownCommand = 6,
+        ExitControlCommand = 6,
         TurnAirOnCommand = 7,
         TurnAirOffCommand = 8,
         ApplyOffsetForcesCommand = 9,

--- a/src/LSST/M1M3/SS/CommandFactory/CommandTypes.h
+++ b/src/LSST/M1M3/SS/CommandFactory/CommandTypes.h
@@ -33,7 +33,7 @@ namespace SS {
  */
 struct Commands {
     enum Type {
-        BootCommand = 0,
+        EnterControlCommand = 0,
         StartCommand = 1,
         EnableCommand = 2,
         DisableCommand = 3,

--- a/src/LSST/M1M3/SS/Commands/AbortProfileCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/AbortProfileCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <AbortProfileCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/AbortRaiseM1M3Command.cpp
+++ b/src/LSST/M1M3/SS/Commands/AbortRaiseM1M3Command.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <AbortRaiseM1M3Command.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ApplyAberrationForcesByBendingModesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ApplyAberrationForcesByBendingModesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ApplyAberrationForcesByBendingModesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ApplyAberrationForcesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ApplyAberrationForcesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ApplyAberrationForcesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ApplyActiveOpticForcesByBendingModesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ApplyActiveOpticForcesByBendingModesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ApplyActiveOpticForcesByBendingModesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ApplyActiveOpticForcesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ApplyActiveOpticForcesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ApplyActiveOpticForcesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ApplyOffsetForcesByMirrorForceCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ApplyOffsetForcesByMirrorForceCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ApplyOffsetForcesByMirrorForceCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ApplyOffsetForcesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ApplyOffsetForcesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ApplyOffsetForcesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ClearAberrationForcesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ClearAberrationForcesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ClearAberrationForcesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ClearActiveOpticForcesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ClearActiveOpticForcesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ClearActiveOpticForcesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ClearOffsetForcesCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ClearOffsetForcesCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ClearOffsetForcesCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/Command.h
+++ b/src/LSST/M1M3/SS/Commands/Command.h
@@ -25,14 +25,14 @@
 #define COMMAND_H_
 
 #include <string>
+#include <Context.h>
 #include <DataTypes.h>
+// TODO remove/refactor with M1M3SSPublisher as singleton
+#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
-
-class Context;
-class M1M3SSPublisher;
 
 class Command {
 protected:

--- a/src/LSST/M1M3/SS/Commands/DisableCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/DisableCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <DisableCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/DisableHardpointChaseCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/DisableHardpointChaseCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <DisableHardpointChaseCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/DisableHardpointCorrectionsCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/DisableHardpointCorrectionsCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <DisableHardpointCorrectionsCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/EnableCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/EnableCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <EnableCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/EnableHardpointChaseCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/EnableHardpointChaseCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <EnableHardpointChaseCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/EnableHardpointCorrectionsCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/EnableHardpointCorrectionsCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <EnableHardpointCorrectionsCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/EnterControlCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/EnterControlCommand.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <EnterControlCommand.h>
-#include <Context.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/EnterControlCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/EnterControlCommand.cpp
@@ -21,32 +21,20 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef BOOTCOMMAND_H_
-#define BOOTCOMMAND_H_
-
-#include <Command.h>
+#include <EnterControlCommand.h>
+#include <Context.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-/*!
- * This command is responsible for transitioning the state
- * machine from the offline state to the standby state.
- * This is an internal command only and cannot be issued via SAL.
- */
-class BootCommand : public Command {
-public:
-    BootCommand(Context* context);
+EnterControlCommand::EnterControlCommand(Context* context) {
+    _context = context;
+    this->commandID = -1;
+}
 
-    void execute();
-
-private:
-    Context* _context;
-};
+void EnterControlCommand::execute() { _context->enterControl(this); }
 
 } /* namespace SS */
 } /* namespace M1M3 */
 } /* namespace LSST */
-
-#endif /* BOOTCOMMAND_H_ */

--- a/src/LSST/M1M3/SS/Commands/EnterControlCommand.h
+++ b/src/LSST/M1M3/SS/Commands/EnterControlCommand.h
@@ -21,20 +21,33 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <BootCommand.h>
-#include <Context.h>
+#ifndef ENTERCONTROLCOMMAND_H_
+#define ENTERCONTROLCOMMAND_H_
+
+#include <Command.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-BootCommand::BootCommand(Context* context) {
-    _context = context;
-    this->commandID = -1;
-}
+/*!
+ * This command is responsible for transitioning the state
+ * machine from the offline state to the standby state.
+ * This is an internal command only and cannot be issued via SAL, as
+ * M1M3Subscriber isn't registering it.
+ */
+class EnterControlCommand : public Command {
+public:
+    EnterControlCommand(Context* context);
 
-void BootCommand::execute() { _context->boot(this); }
+    void execute();
+
+private:
+    Context* _context;
+};
 
 } /* namespace SS */
 } /* namespace M1M3 */
 } /* namespace LSST */
+
+#endif /* ENTERCONTROLCOMMAND_H_ */

--- a/src/LSST/M1M3/SS/Commands/EnterEngineeringCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/EnterEngineeringCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <EnterEngineeringCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ExitControlCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ExitControlCommand.cpp
@@ -21,7 +21,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <ShutdownCommand.h>
+#include <ExitControlCommand.h>
 #include <Context.h>
 #include <M1M3SSPublisher.h>
 
@@ -29,25 +29,25 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-ShutdownCommand::ShutdownCommand(Context* context, M1M3SSPublisher* publisher, int32_t commandID,
-                                 MTM1M3_command_shutdownC*) {
+ExitControlCommand::ExitControlCommand(Context* context, M1M3SSPublisher* publisher, int32_t commandID,
+                                       MTM1M3_command_exitControlC*) {
     _context = context;
     _publisher = publisher;
     this->commandID = commandID;
 }
 
-void ShutdownCommand::execute() { _context->shutdown(this); }
+void ExitControlCommand::execute() { _context->exitControl(this); }
 
-void ShutdownCommand::ackInProgress() {
-    _publisher->ackCommandshutdown(this->commandID, ACK_INPROGRESS, "In-Progress");
+void ExitControlCommand::ackInProgress() {
+    _publisher->ackCommandexitControl(this->commandID, ACK_INPROGRESS, "In-Progress");
 }
 
-void ShutdownCommand::ackComplete() {
-    _publisher->ackCommandshutdown(this->commandID, ACK_COMPLETE, "Complete");
+void ExitControlCommand::ackComplete() {
+    _publisher->ackCommandexitControl(this->commandID, ACK_COMPLETE, "Complete");
 }
 
-void ShutdownCommand::ackFailed(std::string reason) {
-    _publisher->ackCommandshutdown(this->commandID, ACK_FAILED, "Failed: " + reason);
+void ExitControlCommand::ackFailed(std::string reason) {
+    _publisher->ackCommandexitControl(this->commandID, ACK_FAILED, "Failed: " + reason);
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/Commands/ExitControlCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ExitControlCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ExitControlCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ExitControlCommand.h
+++ b/src/LSST/M1M3/SS/Commands/ExitControlCommand.h
@@ -21,8 +21,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SHUTDOWNCOMMAND_H_
-#define SHUTDOWNCOMMAND_H_
+#ifndef EXITCONTROLCOMMAND_H_
+#define EXITCONTROLCOMMAND_H_
 
 #include <Command.h>
 #include <SAL_MTM1M3C.h>
@@ -38,10 +38,10 @@ namespace SS {
  * This is an external command and can be issued via SAL.
  * Once this command has been executed the software will stop running.
  */
-class ShutdownCommand : public Command {
+class ExitControlCommand : public Command {
 public:
-    ShutdownCommand(Context* context, M1M3SSPublisher* publisher, int32_t commandID,
-                    MTM1M3_command_shutdownC*);
+    ExitControlCommand(Context* context, M1M3SSPublisher* publisher, int32_t commandID,
+                       MTM1M3_command_exitControlC*);
 
     void execute() override;
     void ackInProgress() override;
@@ -57,4 +57,4 @@ private:
 } /* namespace M1M3 */
 } /* namespace LSST */
 
-#endif /* SHUTDOWNCOMMAND_H_ */
+#endif /* EXITCONTROLCOMMAND_H_ */

--- a/src/LSST/M1M3/SS/Commands/ExitEngineeringCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ExitEngineeringCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ExitEngineeringCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/LowerM1M3Command.cpp
+++ b/src/LSST/M1M3/SS/Commands/LowerM1M3Command.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <LowerM1M3Command.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ModbusTransmitCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ModbusTransmitCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ModbusTransmitCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/MoveHardpointActuatorsCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/MoveHardpointActuatorsCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <MoveHardpointActuatorsCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/PositionM1M3Command.cpp
+++ b/src/LSST/M1M3/SS/Commands/PositionM1M3Command.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <PositionM1M3Command.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ProgramILCCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ProgramILCCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ProgramILCCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/RaiseM1M3Command.cpp
+++ b/src/LSST/M1M3/SS/Commands/RaiseM1M3Command.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <RaiseM1M3Command.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/ResetPIDCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ResetPIDCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <ResetPIDCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/RunMirrorForceProfileCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/RunMirrorForceProfileCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <RunMirrorForceProfileCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/StandbyCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/StandbyCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <StandbyCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/StartCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/StartCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <StartCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 #include <SAL_defines.h>
 

--- a/src/LSST/M1M3/SS/Commands/StopHardpointMotionCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/StopHardpointMotionCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <StopHardpointMotionCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TMAAzimuthSampleCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TMAAzimuthSampleCommand.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <TMAAzimuthSampleCommand.h>
-#include <Context.h>
 #include <cstring>
 
 namespace LSST {

--- a/src/LSST/M1M3/SS/Commands/TMAElevationSampleCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TMAElevationSampleCommand.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <TMAElevationSampleCommand.h>
-#include <Context.h>
 #include <cstring>
 
 namespace LSST {

--- a/src/LSST/M1M3/SS/Commands/TestAirCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TestAirCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TestAirCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TestForceActuatorCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TestForceActuatorCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TestForceActuatorCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TestHardpointCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TestHardpointCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TestHardpointCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TranslateM1M3Command.cpp
+++ b/src/LSST/M1M3/SS/Commands/TranslateM1M3Command.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TranslateM1M3Command.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TurnAirOffCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TurnAirOffCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TurnAirOffCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TurnAirOnCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TurnAirOnCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TurnAirOnCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TurnLightsOffCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TurnLightsOffCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TurnLightsOffCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TurnLightsOnCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TurnLightsOnCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TurnLightsOnCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TurnPowerOffCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TurnPowerOffCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TurnPowerOffCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/TurnPowerOnCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/TurnPowerOnCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <TurnPowerOnCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/UpdateCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/UpdateCommand.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <UpdateCommand.h>
-#include <Context.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Commands/UpdatePIDCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/UpdatePIDCommand.cpp
@@ -22,8 +22,6 @@
  */
 
 #include <UpdatePIDCommand.h>
-#include <Context.h>
-#include <M1M3SSPublisher.h>
 
 namespace LSST {
 namespace M1M3 {

--- a/src/LSST/M1M3/SS/Context/Context.cpp
+++ b/src/LSST/M1M3/SS/Context/Context.cpp
@@ -38,10 +38,10 @@ Context::Context(StaticStateFactory* stateFactory, Model* model) {
     _currentState = States::OfflineState;
 }
 
-void Context::boot(BootCommand* command) {
-    spdlog::debug("Context: boot()");
+void Context::enterControl(EnterControlCommand* command) {
+    spdlog::debug("Context: enterControl()");
     State* state = _stateFactory->create(_currentState);
-    _updateCurrentStateIfRequired(state->boot(command, _model));
+    _updateCurrentStateIfRequired(state->enterControl(command, _model));
     _stateFactory->destroy(state);
 }
 

--- a/src/LSST/M1M3/SS/Context/Context.cpp
+++ b/src/LSST/M1M3/SS/Context/Context.cpp
@@ -73,10 +73,10 @@ void Context::standby(StandbyCommand* command) {
     _stateFactory->destroy(state);
 }
 
-void Context::shutdown(ShutdownCommand* command) {
-    spdlog::debug("Context: shutdown()");
+void Context::exitControl(ExitControlCommand* command) {
+    spdlog::debug("Context: exitControl()");
     State* state = _stateFactory->create(_currentState);
-    _updateCurrentStateIfRequired(state->shutdown(command, _model));
+    _updateCurrentStateIfRequired(state->exitControl(command, _model));
     _stateFactory->destroy(state);
 }
 

--- a/src/LSST/M1M3/SS/Context/Context.h
+++ b/src/LSST/M1M3/SS/Context/Context.h
@@ -32,7 +32,7 @@ namespace SS {
 
 class StaticStateFactory;
 class Model;
-class BootCommand;
+class EnterControlCommand;
 class StartCommand;
 class EnableCommand;
 class DisableCommand;
@@ -89,7 +89,7 @@ class Context {
 public:
     Context(StaticStateFactory* stateFactory, Model* model);
 
-    void boot(BootCommand* command);
+    void enterControl(EnterControlCommand* command);
     void start(StartCommand* command);
     void enable(EnableCommand* command);
     void disable(DisableCommand* command);

--- a/src/LSST/M1M3/SS/Context/Context.h
+++ b/src/LSST/M1M3/SS/Context/Context.h
@@ -37,7 +37,7 @@ class StartCommand;
 class EnableCommand;
 class DisableCommand;
 class StandbyCommand;
-class ShutdownCommand;
+class ExitControlCommand;
 class UpdateCommand;
 class TurnAirOnCommand;
 class TurnAirOffCommand;
@@ -94,7 +94,7 @@ public:
     void enable(EnableCommand* command);
     void disable(DisableCommand* command);
     void standby(StandbyCommand* command);
-    void shutdown(ShutdownCommand* command);
+    void exitControl(ExitControlCommand* command);
     void update(UpdateCommand* command);
     void turnAirOn(TurnAirOnCommand* command);
     void turnAirOff(TurnAirOffCommand* command);

--- a/src/LSST/M1M3/SS/Model/Model.cpp
+++ b/src/LSST/M1M3/SS/Model/Model.cpp
@@ -221,9 +221,9 @@ void Model::publishOuterLoop(double executionTime) {
     _publisher->putOuterLoopData();
 }
 
-void Model::shutdown() { pthread_mutex_unlock(&_mutex); }
+void Model::exitControl() { pthread_mutex_unlock(&_mutex); }
 
-void Model::waitForShutdown() {
+void Model::waitForExitControl() {
     pthread_mutex_lock(&_mutex);
     pthread_mutex_unlock(&_mutex);
 }

--- a/src/LSST/M1M3/SS/Model/Model.h
+++ b/src/LSST/M1M3/SS/Model/Model.h
@@ -87,8 +87,8 @@ public:
     void publishRecommendedSettings();
     void publishOuterLoop(double executionTime);
 
-    void shutdown();
-    void waitForShutdown();
+    void exitControl();
+    void waitForExitControl();
 
 private:
     void _populateForceActuatorInfo(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,

--- a/src/LSST/M1M3/SS/Publisher/M1M3SSPublisher.cpp
+++ b/src/LSST/M1M3/SS/Publisher/M1M3SSPublisher.cpp
@@ -2252,8 +2252,8 @@ void M1M3SSPublisher::ackCommandstandby(int32_t commandID, int32_t ackCode, std:
     _m1m3SAL->ackCommand_standby(commandID, ackCode, 0, (char*)description.c_str());
 }
 
-void M1M3SSPublisher::ackCommandshutdown(int32_t commandID, int32_t ackCode, std::string description) {
-    _m1m3SAL->ackCommand_shutdown(commandID, ackCode, 0, (char*)description.c_str());
+void M1M3SSPublisher::ackCommandexitControl(int32_t commandID, int32_t ackCode, std::string description) {
+    _m1m3SAL->ackCommand_exitControl(commandID, ackCode, 0, (char*)description.c_str());
 }
 
 void M1M3SSPublisher::ackCommandturnAirOn(int32_t commandID, int32_t ackCode, std::string description) {

--- a/src/LSST/M1M3/SS/Publisher/M1M3SSPublisher.h
+++ b/src/LSST/M1M3/SS/Publisher/M1M3SSPublisher.h
@@ -313,7 +313,7 @@ public:
     void ackCommandenable(int32_t commandID, int32_t ackCode, std::string description);
     void ackCommanddisable(int32_t commandID, int32_t ackCode, std::string description);
     void ackCommandstandby(int32_t commandID, int32_t ackCode, std::string description);
-    void ackCommandshutdown(int32_t commandID, int32_t ackCode, std::string description);
+    void ackCommandexitControl(int32_t commandID, int32_t ackCode, std::string description);
     void ackCommandturnAirOn(int32_t commandID, int32_t ackCode, std::string description);
     void ackCommandturnAirOff(int32_t commandID, int32_t ackCode, std::string description);
     void ackCommandapplyOffsetForces(int32_t commandID, int32_t ackCode, std::string description);

--- a/src/LSST/M1M3/SS/States/ActiveEngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/ActiveEngineeringState.cpp
@@ -73,15 +73,13 @@ States::Type ActiveEngineeringState::update(UpdateCommand* command, Model* model
 
 States::Type ActiveEngineeringState::lowerM1M3(LowerM1M3Command* command, Model* model) {
     spdlog::info("ActiveEngineeringState: lowerM1M3()");
-    States::Type newState = States::LoweringEngineeringState;
     model->getForceController()->resetPIDs();
     model->getAutomaticOperationsController()->startLowerOperation();
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::LoweringEngineeringState);
 }
 
 States::Type ActiveEngineeringState::exitEngineering(ExitEngineeringCommand* command, Model* model) {
     spdlog::info("ActiveEngineeringState: exitEngineering()");
-    States::Type newState = States::ActiveState;
     model->getForceController()->resetPIDs();
     model->getDigitalInputOutput()->turnAirOn();
     model->getPositionController()->stopMotion();
@@ -92,7 +90,7 @@ States::Type ActiveEngineeringState::exitEngineering(ExitEngineeringCommand* com
     model->getDigitalInputOutput()->turnCellLightsOff();
     // TODO: Real problems exist if the user enabled / disabled ILC power...
     model->getPowerController()->setAllPowerNetworks(true);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::ActiveState);
 }
 
 States::Type ActiveEngineeringState::applyAberrationForcesByBendingModes(

--- a/src/LSST/M1M3/SS/States/ActiveEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/ActiveEngineeringState.h
@@ -34,24 +34,28 @@ class ActiveEngineeringState : public EngineeringState {
 public:
     ActiveEngineeringState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type lowerM1M3(LowerM1M3Command* command, Model* model);
-    States::Type exitEngineering(ExitEngineeringCommand* command, Model* model);
-    States::Type applyAberrationForcesByBendingModes(ApplyAberrationForcesByBendingModesCommand* command,
-                                                     Model* model);
-    States::Type applyAberrationForces(ApplyAberrationForcesCommand* command, Model* model);
-    States::Type clearAberrationForces(ClearAberrationForcesCommand* command, Model* model);
-    States::Type applyActiveOpticForcesByBendingModes(ApplyActiveOpticForcesByBendingModesCommand* command,
-                                                      Model* model);
-    States::Type applyActiveOpticForces(ApplyActiveOpticForcesCommand* command, Model* model);
-    States::Type clearActiveOpticForces(ClearActiveOpticForcesCommand* command, Model* model);
-    States::Type translateM1M3(TranslateM1M3Command* command, Model* model);
-    States::Type positionM1M3(PositionM1M3Command* command, Model* model);
-    States::Type enableHardpointCorrections(EnableHardpointCorrectionsCommand* command, Model* model);
-    States::Type disableHardpointCorrections(DisableHardpointCorrectionsCommand* command, Model* model);
-    States::Type runMirrorForceProfile(RunMirrorForceProfileCommand* command, Model* model);
-    States::Type updatePID(UpdatePIDCommand* command, Model* model);
-    States::Type resetPID(ResetPIDCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type lowerM1M3(LowerM1M3Command* command, Model* model) override;
+    virtual States::Type exitEngineering(ExitEngineeringCommand* command, Model* model) override;
+    virtual States::Type applyAberrationForcesByBendingModes(
+            ApplyAberrationForcesByBendingModesCommand* command, Model* model) override;
+    virtual States::Type applyAberrationForces(ApplyAberrationForcesCommand* command, Model* model) override;
+    virtual States::Type clearAberrationForces(ClearAberrationForcesCommand* command, Model* model) override;
+    virtual States::Type applyActiveOpticForcesByBendingModes(
+            ApplyActiveOpticForcesByBendingModesCommand* command, Model* model) override;
+    virtual States::Type applyActiveOpticForces(ApplyActiveOpticForcesCommand* command,
+                                                Model* model) override;
+    virtual States::Type clearActiveOpticForces(ClearActiveOpticForcesCommand* command,
+                                                Model* model) override;
+    virtual States::Type translateM1M3(TranslateM1M3Command* command, Model* model) override;
+    virtual States::Type positionM1M3(PositionM1M3Command* command, Model* model) override;
+    virtual States::Type enableHardpointCorrections(EnableHardpointCorrectionsCommand* command,
+                                                    Model* model) override;
+    virtual States::Type disableHardpointCorrections(DisableHardpointCorrectionsCommand* command,
+                                                     Model* model) override;
+    virtual States::Type runMirrorForceProfile(RunMirrorForceProfileCommand* command, Model* model) override;
+    virtual States::Type updatePID(UpdatePIDCommand* command, Model* model) override;
+    virtual States::Type resetPID(ResetPIDCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/ActiveState.cpp
+++ b/src/LSST/M1M3/SS/States/ActiveState.cpp
@@ -46,15 +46,13 @@ States::Type ActiveState::update(UpdateCommand* command, Model* model) {
 
 States::Type ActiveState::enterEngineering(EnterEngineeringCommand* command, Model* model) {
     spdlog::info("ActiveState: enterEngineering()");
-    States::Type newState = States::ActiveEngineeringState;
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::ActiveEngineeringState);
 }
 
 States::Type ActiveState::lowerM1M3(LowerM1M3Command* command, Model* model) {
     spdlog::info("ActiveState: lowerM1M3()");
-    States::Type newState = States::LoweringState;
     model->getAutomaticOperationsController()->startLowerOperation();
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::LoweringState);
 }
 
 States::Type ActiveState::enableHardpointCorrections(EnableHardpointCorrectionsCommand* command,

--- a/src/LSST/M1M3/SS/States/ActiveState.h
+++ b/src/LSST/M1M3/SS/States/ActiveState.h
@@ -34,11 +34,13 @@ class ActiveState : public EnabledState {
 public:
     ActiveState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type enterEngineering(EnterEngineeringCommand* command, Model* model);
-    States::Type lowerM1M3(LowerM1M3Command* command, Model* model);
-    States::Type enableHardpointCorrections(EnableHardpointCorrectionsCommand* command, Model* model);
-    States::Type disableHardpointCorrections(DisableHardpointCorrectionsCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type enterEngineering(EnterEngineeringCommand* command, Model* model) override;
+    virtual States::Type lowerM1M3(LowerM1M3Command* command, Model* model) override;
+    virtual States::Type enableHardpointCorrections(EnableHardpointCorrectionsCommand* command,
+                                                    Model* model) override;
+    virtual States::Type disableHardpointCorrections(DisableHardpointCorrectionsCommand* command,
+                                                     Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/DisabledState.cpp
+++ b/src/LSST/M1M3/SS/States/DisabledState.cpp
@@ -80,7 +80,6 @@ States::Type DisabledState::update(UpdateCommand* command, Model* model) {
 
 States::Type DisabledState::enable(EnableCommand* command, Model* model) {
     spdlog::info("DisabledState: enable()");
-    States::Type newState = States::ParkedState;
     model->getILC()->writeSetModeEnableBuffer();
     model->getILC()->triggerModbus();
     model->getILC()->waitForAllSubnets(5000);
@@ -88,12 +87,11 @@ States::Type DisabledState::enable(EnableCommand* command, Model* model) {
     model->getILC()->verifyResponses();
     model->getDigitalInputOutput()->turnAirOn();
     model->getPowerController()->setAllAuxPowerNetworks(true);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::ParkedState);
 }
 
 States::Type DisabledState::standby(StandbyCommand* command, Model* model) {
     spdlog::info("DisabledState: standby()");
-    States::Type newState = States::StandbyState;
     model->getILC()->writeSetModeStandbyBuffer();
     model->getILC()->triggerModbus();
     model->getILC()->waitForAllSubnets(5000);
@@ -101,7 +99,7 @@ States::Type DisabledState::standby(StandbyCommand* command, Model* model) {
     model->getILC()->verifyResponses();
     model->getPublisher()->tryLogForceActuatorState();
     model->getPowerController()->setBothPowerNetworks(false);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::StandbyState);
 }
 
 States::Type DisabledState::programILC(ProgramILCCommand* command, Model* model) {

--- a/src/LSST/M1M3/SS/States/DisabledState.h
+++ b/src/LSST/M1M3/SS/States/DisabledState.h
@@ -34,11 +34,11 @@ class DisabledState : public State {
 public:
     DisabledState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type enable(EnableCommand* command, Model* model);
-    States::Type standby(StandbyCommand* command, Model* model);
-    States::Type programILC(ProgramILCCommand* command, Model* model);
-    States::Type modbusTransmit(ModbusTransmitCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type enable(EnableCommand* command, Model* model) override;
+    virtual States::Type standby(StandbyCommand* command, Model* model) override;
+    virtual States::Type programILC(ProgramILCCommand* command, Model* model) override;
+    virtual States::Type modbusTransmit(ModbusTransmitCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/EnabledState.h
+++ b/src/LSST/M1M3/SS/States/EnabledState.h
@@ -35,10 +35,10 @@ public:
     EnabledState(M1M3SSPublisher* publisher);
     EnabledState(M1M3SSPublisher* publisher, std::string name);
 
-    virtual States::Type update(UpdateCommand* command, Model* model);
-    States::Type storeTMAAzimuthSample(TMAAzimuthSampleCommand* command, Model* model);
-    States::Type storeTMAElevationSample(TMAElevationSampleCommand* command, Model* model);
-    States::Type testAir(TestAirCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type storeTMAAzimuthSample(TMAAzimuthSampleCommand* command, Model* model) override;
+    virtual States::Type storeTMAElevationSample(TMAElevationSampleCommand* command, Model* model) override;
+    virtual States::Type testAir(TestAirCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/EngineeringState.h
+++ b/src/LSST/M1M3/SS/States/EngineeringState.h
@@ -35,21 +35,22 @@ public:
     EngineeringState(M1M3SSPublisher* publisher);
     EngineeringState(M1M3SSPublisher* publisher, std::string name);
 
-    States::Type turnAirOn(TurnAirOnCommand* command, Model* model);
-    States::Type turnAirOff(TurnAirOffCommand* command, Model* model);
-    virtual States::Type stopHardpointMotion(StopHardpointMotionCommand* command, Model* model);
-    virtual States::Type moveHardpointActuators(MoveHardpointActuatorsCommand* command, Model* model);
-    virtual States::Type enableHardpointChase(EnableHardpointChaseCommand* command, Model* model);
-    virtual States::Type disableHardpointChase(DisableHardpointChaseCommand* command, Model* model);
-    virtual States::Type applyOffsetForces(ApplyOffsetForcesCommand* command, Model* model);
+    virtual States::Type turnAirOn(TurnAirOnCommand* command, Model* model) override;
+    virtual States::Type turnAirOff(TurnAirOffCommand* command, Model* model) override;
+    virtual States::Type stopHardpointMotion(StopHardpointMotionCommand* command, Model* model) override;
+    virtual States::Type moveHardpointActuators(MoveHardpointActuatorsCommand* command,
+                                                Model* model) override;
+    virtual States::Type enableHardpointChase(EnableHardpointChaseCommand* command, Model* model) override;
+    virtual States::Type disableHardpointChase(DisableHardpointChaseCommand* command, Model* model) override;
+    virtual States::Type applyOffsetForces(ApplyOffsetForcesCommand* command, Model* model) override;
     virtual States::Type applyOffsetForcesByMirrorForce(ApplyOffsetForcesByMirrorForceCommand* command,
-                                                        Model* model);
-    virtual States::Type clearOffsetForces(ClearOffsetForcesCommand* command, Model* model);
-    States::Type turnLightsOn(TurnLightsOnCommand* command, Model* model);
-    States::Type turnLightsOff(TurnLightsOffCommand* command, Model* model);
-    States::Type turnPowerOn(TurnPowerOnCommand* command, Model* model);
-    States::Type turnPowerOff(TurnPowerOffCommand* command, Model* model);
-    States::Type modbusTransmit(ModbusTransmitCommand* command, Model* model);
+                                                        Model* model) override;
+    virtual States::Type clearOffsetForces(ClearOffsetForcesCommand* command, Model* model) override;
+    virtual States::Type turnLightsOn(TurnLightsOnCommand* command, Model* model) override;
+    virtual States::Type turnLightsOff(TurnLightsOffCommand* command, Model* model) override;
+    virtual States::Type turnPowerOn(TurnPowerOnCommand* command, Model* model) override;
+    virtual States::Type turnPowerOff(TurnPowerOffCommand* command, Model* model) override;
+    virtual States::Type modbusTransmit(ModbusTransmitCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/FaultState.cpp
+++ b/src/LSST/M1M3/SS/States/FaultState.cpp
@@ -78,7 +78,6 @@ States::Type FaultState::update(UpdateCommand* command, Model* model) {
 
 States::Type FaultState::standby(StandbyCommand* command, Model* model) {
     spdlog::trace("FaultState: standby()");
-    States::Type newState = States::StandbyState;
     model->getILC()->writeSetModeStandbyBuffer();
     model->getILC()->triggerModbus();
     model->getILC()->waitForAllSubnets(5000);
@@ -86,7 +85,7 @@ States::Type FaultState::standby(StandbyCommand* command, Model* model) {
     model->getILC()->verifyResponses();
     model->getPowerController()->setAllPowerNetworks(false);
     model->getSafetyController()->clearErrorCode();
-    return newState;
+    return States::StandbyState;
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/FaultState.h
+++ b/src/LSST/M1M3/SS/States/FaultState.h
@@ -35,8 +35,8 @@ public:
     FaultState(M1M3SSPublisher* publisher);
     FaultState(M1M3SSPublisher* publisher, std::string name);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type standby(StandbyCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type standby(StandbyCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/LoweringEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/LoweringEngineeringState.h
@@ -34,7 +34,7 @@ class LoweringEngineeringState : public EngineeringState {
 public:
     LoweringEngineeringState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/LoweringFaultState.h
+++ b/src/LSST/M1M3/SS/States/LoweringFaultState.h
@@ -38,7 +38,7 @@ class LoweringFaultState : public FaultState {
 public:
     LoweringFaultState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/LoweringState.h
+++ b/src/LSST/M1M3/SS/States/LoweringState.h
@@ -34,7 +34,7 @@ class LoweringState : public EnabledState {
 public:
     LoweringState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/OfflineState.cpp
+++ b/src/LSST/M1M3/SS/States/OfflineState.cpp
@@ -33,8 +33,8 @@ namespace SS {
 
 OfflineState::OfflineState(M1M3SSPublisher* publisher) : State(publisher, "OfflineState") {}
 
-States::Type OfflineState::boot(BootCommand* command, Model* model) {
-    spdlog::info("OfflineState: boot()");
+States::Type OfflineState::enterControl(EnterControlCommand* command, Model* model) {
+    spdlog::info("OfflineState: enterControl()");
     States::Type newState = States::StandbyState;
     model->publishRecommendedSettings();
     // model->getDigitalInputOutput()->turnAirOff();

--- a/src/LSST/M1M3/SS/States/OfflineState.cpp
+++ b/src/LSST/M1M3/SS/States/OfflineState.cpp
@@ -35,7 +35,6 @@ OfflineState::OfflineState(M1M3SSPublisher* publisher) : State(publisher, "Offli
 
 States::Type OfflineState::enterControl(EnterControlCommand* command, Model* model) {
     spdlog::info("OfflineState: enterControl()");
-    States::Type newState = States::StandbyState;
     model->publishRecommendedSettings();
     // model->getDigitalInputOutput()->turnAirOff();
     // model->getDigitalInputOutput()->turnCellLightsOff();
@@ -43,7 +42,7 @@ States::Type OfflineState::enterControl(EnterControlCommand* command, Model* mod
     model->getDigitalInputOutput()->turnAirOn();
     // TODO: May need to change power controller to act like digital input output
     // model->getPowerController()->setBothPowerNetworks(false);
-    return newState;
+    return States::StandbyState;
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/OfflineState.h
+++ b/src/LSST/M1M3/SS/States/OfflineState.h
@@ -34,7 +34,7 @@ class OfflineState : public State {
 public:
     OfflineState(M1M3SSPublisher* publisher);
 
-    virtual States::Type boot(BootCommand* command, Model* model) override;
+    virtual States::Type enterControl(EnterControlCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/OfflineState.h
+++ b/src/LSST/M1M3/SS/States/OfflineState.h
@@ -34,7 +34,7 @@ class OfflineState : public State {
 public:
     OfflineState(M1M3SSPublisher* publisher);
 
-    virtual States::Type boot(BootCommand* command, Model* model);
+    virtual States::Type boot(BootCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/ParkedEngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/ParkedEngineeringState.cpp
@@ -61,15 +61,13 @@ States::Type ParkedEngineeringState::update(UpdateCommand* command, Model* model
 
 States::Type ParkedEngineeringState::raiseM1M3(RaiseM1M3Command* command, Model* model) {
     spdlog::info("ParkedEngineeringState: raiseM1M3()");
-    States::Type newState = States::RaisingEngineeringState;
     model->getAutomaticOperationsController()->startRaiseOperation(
             command->getData()->bypassReferencePosition);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::RaisingEngineeringState);
 }
 
 States::Type ParkedEngineeringState::exitEngineering(ExitEngineeringCommand* command, Model* model) {
     spdlog::info("ParkedEngineeringState: exitEngineering()");
-    States::Type newState = States::ParkedState;
     model->getDigitalInputOutput()->turnAirOn();
     model->getPositionController()->stopMotion();
     model->getForceController()->zeroOffsetForces();
@@ -77,12 +75,11 @@ States::Type ParkedEngineeringState::exitEngineering(ExitEngineeringCommand* com
     model->getDigitalInputOutput()->turnCellLightsOff();
     // TODO: Real problems exist if the user enabled / disabled ILC power...
     model->getPowerController()->setAllPowerNetworks(true);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::ParkedState);
 }
 
 States::Type ParkedEngineeringState::disable(DisableCommand* command, Model* model) {
     spdlog::info("ParkedEngineeringState: disable()");
-    States::Type newState = States::DisabledState;
     // Stop any existing motion (chase and move commands)
     model->getPositionController()->stopMotion();
     model->getForceController()->reset();
@@ -95,7 +92,7 @@ States::Type ParkedEngineeringState::disable(DisableCommand* command, Model* mod
     // TODO: Uncomment this later when its not so hot outside
     // model->getDigitalInputOutput()->turnAirOff();
     model->getPowerController()->setAllAuxPowerNetworks(false);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::DisabledState);
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/ParkedEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/ParkedEngineeringState.h
@@ -34,10 +34,10 @@ class ParkedEngineeringState : public EngineeringState {
 public:
     ParkedEngineeringState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type raiseM1M3(RaiseM1M3Command* command, Model* model);
-    States::Type exitEngineering(ExitEngineeringCommand* command, Model* model);
-    States::Type disable(DisableCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type raiseM1M3(RaiseM1M3Command* command, Model* model) override;
+    virtual States::Type exitEngineering(ExitEngineeringCommand* command, Model* model) override;
+    virtual States::Type disable(DisableCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/ParkedState.cpp
+++ b/src/LSST/M1M3/SS/States/ParkedState.cpp
@@ -57,20 +57,17 @@ States::Type ParkedState::raiseM1M3(RaiseM1M3Command* command, Model* model) {
                 "The BypassReferencePosition parameter of the RaiseM1M3 cannot be true in the ParkedState.");
         return model->getSafetyController()->checkSafety(States::NoStateTransition);
     }
-    States::Type newState = States::RaisingState;
     model->getAutomaticOperationsController()->startRaiseOperation(false);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::RaisingState);
 }
 
 States::Type ParkedState::enterEngineering(EnterEngineeringCommand* command, Model* model) {
     spdlog::info("ParkedState: enterEngineering()");
-    States::Type newState = States::ParkedEngineeringState;
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::ParkedEngineeringState);
 }
 
 States::Type ParkedState::disable(DisableCommand* command, Model* model) {
     spdlog::info("ParkedState: disable()");
-    States::Type newState = States::DisabledState;
     model->getILC()->writeSetModeDisableBuffer();
     model->getILC()->triggerModbus();
     model->getILC()->waitForAllSubnets(5000);
@@ -80,7 +77,7 @@ States::Type ParkedState::disable(DisableCommand* command, Model* model) {
     // TODO: Uncomment this when its not so hot outside
     // model->getDigitalInputOutput()->turnAirOff();
     model->getPowerController()->setAllAuxPowerNetworks(false);
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::DisabledState);
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/ParkedState.h
+++ b/src/LSST/M1M3/SS/States/ParkedState.h
@@ -34,10 +34,10 @@ class ParkedState : public EnabledState {
 public:
     ParkedState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type raiseM1M3(RaiseM1M3Command* command, Model* model);
-    States::Type enterEngineering(EnterEngineeringCommand* command, Model* model);
-    States::Type disable(DisableCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type raiseM1M3(RaiseM1M3Command* command, Model* model) override;
+    virtual States::Type enterEngineering(EnterEngineeringCommand* command, Model* model) override;
+    virtual States::Type disable(DisableCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/ProfileHardpointCorrectionState.h
+++ b/src/LSST/M1M3/SS/States/ProfileHardpointCorrectionState.h
@@ -38,8 +38,8 @@ class ProfileHardpointCorrectionState : public EnabledState {
 public:
     ProfileHardpointCorrectionState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type abortProfile(AbortProfileCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type abortProfile(AbortProfileCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/RaisingEngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/RaisingEngineeringState.cpp
@@ -53,9 +53,8 @@ States::Type RaisingEngineeringState::update(UpdateCommand* command, Model* mode
 
 States::Type RaisingEngineeringState::abortRaiseM1M3(AbortRaiseM1M3Command* command, Model* model) {
     spdlog::info("RaisingEngineeringState: abortRaiseM1M3()");
-    States::Type newState = States::LoweringEngineeringState;
     model->getAutomaticOperationsController()->abortRaiseM1M3();
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::LoweringEngineeringState);
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/RaisingEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/RaisingEngineeringState.h
@@ -34,8 +34,8 @@ class RaisingEngineeringState : public EngineeringState {
 public:
     RaisingEngineeringState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type abortRaiseM1M3(AbortRaiseM1M3Command* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type abortRaiseM1M3(AbortRaiseM1M3Command* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/RaisingState.cpp
+++ b/src/LSST/M1M3/SS/States/RaisingState.cpp
@@ -52,9 +52,8 @@ States::Type RaisingState::update(UpdateCommand* command, Model* model) {
 
 States::Type RaisingState::abortRaiseM1M3(AbortRaiseM1M3Command* command, Model* model) {
     spdlog::info("RaisingState: abortRaiseM1M3()");
-    States::Type newState = States::LoweringState;
     model->getAutomaticOperationsController()->abortRaiseM1M3();
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::LoweringState);
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/RaisingState.h
+++ b/src/LSST/M1M3/SS/States/RaisingState.h
@@ -34,8 +34,8 @@ class RaisingState : public EnabledState {
 public:
     RaisingState(M1M3SSPublisher* publisher);
 
-    States::Type update(UpdateCommand* command, Model* model);
-    States::Type abortRaiseM1M3(AbortRaiseM1M3Command* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type abortRaiseM1M3(AbortRaiseM1M3Command* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/StandbyState.cpp
+++ b/src/LSST/M1M3/SS/States/StandbyState.cpp
@@ -48,7 +48,6 @@ States::Type StandbyState::update(UpdateCommand* command, Model* model) {
 
 States::Type StandbyState::start(StartCommand* command, Model* model) {
     spdlog::info("StandbyState: start()");
-    States::Type newState = States::DisabledState;
     model->loadSettings(command->getData()->settingsToApply);
     PowerController* powerController = model->getPowerController();
     ILC* ilc = model->getILC();
@@ -123,14 +122,13 @@ States::Type StandbyState::start(StartCommand* command, Model* model) {
     gyro->exitConfigurationMode();
     gyro->bit();
     digitalInputOutput->tryToggleHeartbeat();
-    return model->getSafetyController()->checkSafety(newState);
+    return model->getSafetyController()->checkSafety(States::DisabledState);
 }
 
 States::Type StandbyState::exitControl(ExitControlCommand* command, Model* model) {
     spdlog::info("StandbyState: ExitControl()");
-    States::Type newState = States::OfflineState;
     model->exitControl();
-    return newState;
+    return States::OfflineState;
 }
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/StandbyState.cpp
+++ b/src/LSST/M1M3/SS/States/StandbyState.cpp
@@ -126,10 +126,10 @@ States::Type StandbyState::start(StartCommand* command, Model* model) {
     return model->getSafetyController()->checkSafety(newState);
 }
 
-States::Type StandbyState::shutdown(ShutdownCommand* command, Model* model) {
-    spdlog::info("StandbyState: shutdown()");
+States::Type StandbyState::exitControl(ExitControlCommand* command, Model* model) {
+    spdlog::info("StandbyState: ExitControl()");
     States::Type newState = States::OfflineState;
-    model->shutdown();
+    model->exitControl();
     return newState;
 }
 

--- a/src/LSST/M1M3/SS/States/StandbyState.h
+++ b/src/LSST/M1M3/SS/States/StandbyState.h
@@ -34,9 +34,9 @@ class StandbyState : public State {
 public:
     StandbyState(M1M3SSPublisher* publisher);
 
-    virtual States::Type update(UpdateCommand* command, Model* model);
-    virtual States::Type start(StartCommand* command, Model* model);
-    virtual States::Type shutdown(ShutdownCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
+    virtual States::Type start(StartCommand* command, Model* model) override;
+    virtual States::Type shutdown(ShutdownCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/StandbyState.h
+++ b/src/LSST/M1M3/SS/States/StandbyState.h
@@ -36,7 +36,7 @@ public:
 
     virtual States::Type update(UpdateCommand* command, Model* model) override;
     virtual States::Type start(StartCommand* command, Model* model) override;
-    virtual States::Type shutdown(ShutdownCommand* command, Model* model) override;
+    virtual States::Type exitControl(ExitControlCommand* command, Model* model) override;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/State.cpp
+++ b/src/LSST/M1M3/SS/States/State.cpp
@@ -49,8 +49,8 @@ States::Type State::disable(DisableCommand* command, Model* model) {
 States::Type State::standby(StandbyCommand* command, Model* model) {
     return this->rejectCommandInvalidState(command, "Standby");
 }
-States::Type State::shutdown(ShutdownCommand* command, Model* model) {
-    return this->rejectCommandInvalidState(command, "Shutdown");
+States::Type State::exitControl(ExitControlCommand* command, Model* model) {
+    return this->rejectCommandInvalidState(command, "ExitControl");
 }
 States::Type State::update(UpdateCommand* command, Model* model) { return States::NoStateTransition; }
 States::Type State::turnAirOn(TurnAirOnCommand* command, Model* model) {

--- a/src/LSST/M1M3/SS/States/State.cpp
+++ b/src/LSST/M1M3/SS/States/State.cpp
@@ -36,7 +36,9 @@ State::State(M1M3SSPublisher* publisher, std::string name) {
 
 State::~State() {}
 
-States::Type State::boot(BootCommand* command, Model* model) { return States::NoStateTransition; }
+States::Type State::enterControl(EnterControlCommand* command, Model* model) {
+    return States::NoStateTransition;
+}
 States::Type State::start(StartCommand* command, Model* model) {
     return this->rejectCommandInvalidState(command, "Start");
 }

--- a/src/LSST/M1M3/SS/States/State.h
+++ b/src/LSST/M1M3/SS/States/State.h
@@ -31,7 +31,7 @@
 #include <Model.h>
 #include <M1M3SSPublisher.h>
 #include <Command.h>
-#include <BootCommand.h>
+#include <EnterControlCommand.h>
 #include <StartCommand.h>
 #include <EnableCommand.h>
 #include <DisableCommand.h>
@@ -93,7 +93,7 @@ public:
     State(M1M3SSPublisher* publisher, std::string name);
     virtual ~State();
 
-    virtual States::Type boot(BootCommand* command, Model* model);
+    virtual States::Type enterControl(EnterControlCommand* command, Model* model);
     virtual States::Type start(StartCommand* command, Model* model);
     virtual States::Type enable(EnableCommand* command, Model* model);
     virtual States::Type disable(DisableCommand* command, Model* model);

--- a/src/LSST/M1M3/SS/States/State.h
+++ b/src/LSST/M1M3/SS/States/State.h
@@ -36,7 +36,7 @@
 #include <EnableCommand.h>
 #include <DisableCommand.h>
 #include <StandbyCommand.h>
-#include <ShutdownCommand.h>
+#include <ExitControlCommand.h>
 #include <UpdateCommand.h>
 #include <TurnAirOnCommand.h>
 #include <TurnAirOffCommand.h>
@@ -98,7 +98,7 @@ public:
     virtual States::Type enable(EnableCommand* command, Model* model);
     virtual States::Type disable(DisableCommand* command, Model* model);
     virtual States::Type standby(StandbyCommand* command, Model* model);
-    virtual States::Type shutdown(ShutdownCommand* command, Model* model);
+    virtual States::Type exitControl(ExitControlCommand* command, Model* model);
     virtual States::Type update(UpdateCommand* command, Model* model);
     virtual States::Type turnAirOn(TurnAirOnCommand* command, Model* model);
     virtual States::Type turnAirOff(TurnAirOffCommand* command, Model* model);

--- a/src/LSST/M1M3/SS/Subscriber/M1M3SSSubscriber.cpp
+++ b/src/LSST/M1M3/SS/Subscriber/M1M3SSSubscriber.cpp
@@ -41,7 +41,7 @@ M1M3SSSubscriber::M1M3SSSubscriber(std::shared_ptr<SAL_MTM1M3> m1m3SAL,
     _m1m3SAL->salProcessor((char*)"MTM1M3_command_enable");
     _m1m3SAL->salProcessor((char*)"MTM1M3_command_disable");
     _m1m3SAL->salProcessor((char*)"MTM1M3_command_standby");
-    _m1m3SAL->salProcessor((char*)"MTM1M3_command_shutdown");
+    _m1m3SAL->salProcessor((char*)"MTM1M3_command_exitControl");
     _m1m3SAL->salProcessor((char*)"MTM1M3_command_turnAirOn");
     _m1m3SAL->salProcessor((char*)"MTM1M3_command_turnAirOff");
     _m1m3SAL->salProcessor((char*)"MTM1M3_command_applyOffsetForces");
@@ -115,10 +115,10 @@ Command* M1M3SSSubscriber::tryAcceptCommandStandby() {
     return 0;
 }
 
-Command* M1M3SSSubscriber::tryAcceptCommandShutdown() {
-    int32_t commandID = _m1m3SAL->acceptCommand_shutdown(&_shutdownData);
+Command* M1M3SSSubscriber::tryAcceptCommandExitControl() {
+    int32_t commandID = _m1m3SAL->acceptCommand_exitControl(&_exitControlData);
     if (commandID > 0) {
-        return _commandFactory->create(Commands::ShutdownCommand, &_shutdownData, commandID);
+        return _commandFactory->create(Commands::ExitControlCommand, &_exitControlData, commandID);
     }
     return 0;
 }

--- a/src/LSST/M1M3/SS/Subscriber/M1M3SSSubscriber.h
+++ b/src/LSST/M1M3/SS/Subscriber/M1M3SSSubscriber.h
@@ -50,7 +50,7 @@ public:
     Command* tryAcceptCommandEnable();
     Command* tryAcceptCommandDisable();
     Command* tryAcceptCommandStandby();
-    Command* tryAcceptCommandShutdown();
+    Command* tryAcceptCommandExitControl();
     Command* tryAcceptCommandTurnAirOn();
     Command* tryAcceptCommandTurnAirOff();
     Command* tryAcceptCommandApplyOffsetForces();
@@ -99,7 +99,7 @@ private:
     MTM1M3_command_enableC _enableData;
     MTM1M3_command_disableC _disableData;
     MTM1M3_command_standbyC _standbyData;
-    MTM1M3_command_shutdownC _shutdownData;
+    MTM1M3_command_exitControlC _exitControlData;
     MTM1M3_command_turnAirOnC _turnAirOnData;
     MTM1M3_command_turnAirOffC _turnAirOffData;
     MTM1M3_command_applyOffsetForcesC _applyOffsetForcesData;

--- a/src/LSST/M1M3/SS/Threads/SubscriberThread.cpp
+++ b/src/LSST/M1M3/SS/Threads/SubscriberThread.cpp
@@ -50,7 +50,7 @@ void SubscriberThread::run() {
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandEnable());
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandDisable());
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandStandby());
-        _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandShutdown());
+        _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandExitControl());
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandTurnAirOn());
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandTurnAirOff());
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandApplyOffsetForces());

--- a/src/ts_M1M3Support.cpp
+++ b/src/ts_M1M3Support.cpp
@@ -152,8 +152,8 @@ void runFPGAs(M1M3SSPublisher* publisher, std::shared_ptr<SAL_MTM1M3> m1m3SAL,
     OuterLoopClockThread outerLoopClockThread = OuterLoopClockThread(&commandFactory, &controller, publisher);
     spdlog::info("Main: Creating pps thread");
     PPSThread ppsThread = PPSThread(publisher);
-    spdlog::info("Main: Queuing boot command");
-    controller.enqueue(commandFactory.create(Commands::BootCommand));
+    spdlog::info("Main: Queuing EnterControl command");
+    controller.enqueue(commandFactory.create(Commands::EnterControlCommand));
 
     pthread_t subscriberThreadId;
     pthread_t controllerThreadId;

--- a/src/ts_M1M3Support.cpp
+++ b/src/ts_M1M3Support.cpp
@@ -178,9 +178,9 @@ void runFPGAs(M1M3SSPublisher* publisher, std::shared_ptr<SAL_MTM1M3> m1m3SAL,
                 rc = pthread_create(&outerLoopClockThreadId, &threadAttribute, runThread,
                                     (void*)(&outerLoopClockThread));
                 if (!rc) {
-                    spdlog::info("Main: Waiting for shutdown");
-                    model.waitForShutdown();
-                    spdlog::info("Main: Shutdown received");
+                    spdlog::info("Main: Waiting for ExitControl");
+                    model.waitForExitControl();
+                    spdlog::info("Main: ExitControl received");
                     spdlog::info("Main: Stopping pps thread");
                     ppsThread.stop();
                     spdlog::info("Main: Stopping subscriber thread");


### PR DESCRIPTION
Replaces (mostly ignored) return values with throwing a NiError. This makes
FPGA related problems (crashes, timeouts,..) more visible and removes return
chaining (when a method returns value only for calling method to return the
same value for error detection upstream).