### PR TITLE
DM-25997: state review

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -6,10 +6,10 @@ endif
 # compile x86 simulator or real cRIO stuff
 ifdef SIMULATOR
   C := gcc -O3 -Wall -g
-  CPP := g++ -std=c++11 -pedantic -O3 -Wall -g -DSIMULATOR
+  CPP := g++ -std=c++14 -pedantic -O3 -Wall -g -DSIMULATOR
 else
   C := gcc -Wall -g -fmessage-length=0
-  CPP := g++ -std=c++11 -Wall -fmessage-length=0 -g
+  CPP := g++ -std=c++14 -Wall -fmessage-length=0 -g
   m1m3cli := m1m3cli
 endif
 

--- a/Tests/test_Timestamp.cpp
+++ b/Tests/test_Timestamp.cpp
@@ -1,0 +1,82 @@
+/*
+ * This file is part of LSST M1M3 SS test suite. Tests Modbus buffer class.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch/catch.hpp>
+
+#include <memory>
+#include <cmath>
+
+#include <Timestamp.h>
+
+using namespace LSST::M1M3::SS;
+
+TEST_CASE("fromRaw", "[Timestamp]") {
+    REQUIRE(Timestamp::fromRaw(1200000000) == 1.2);
+    REQUIRE(Timestamp::fromRaw(98) == 0.000000098);
+}
+
+TEST_CASE("toRaw", "[Timestamp]") {
+    REQUIRE(Timestamp::toRaw(1.234567891) == 1234567891);
+    REQUIRE(Timestamp::toRaw(0.000000001) == 1);
+    REQUIRE(Timestamp::toRaw(999999999) == (uint64_t)999999999000000000);
+}
+
+TEST_CASE("fromRaw<->toRaw", "[Timestamp]") {
+    REQUIRE(Timestamp::toRaw(Timestamp::fromRaw(1)) == 1);
+    REQUIRE(Timestamp::toRaw(Timestamp::fromRaw(33567335.12)) == 33567335);
+
+    REQUIRE(Timestamp::fromRaw(Timestamp::toRaw(1)) == 1);
+    REQUIRE(Timestamp::fromRaw(Timestamp::toRaw(33567335.12)) == 33567335.12);
+}
+
+TEST_CASE("fromFPGA", "[Timestamp]") {
+    REQUIRE(Timestamp::fromFPGA(1200000000) == 1.2);
+    REQUIRE(Timestamp::fromFPGA(98) == 0.000000098);
+}
+
+TEST_CASE("toFPGA", "[Timestamp]") {
+    REQUIRE(Timestamp::toFPGA(1.234567891) == 1234567891);
+    REQUIRE(Timestamp::toFPGA(0.000000001) == 1);
+    REQUIRE(Timestamp::toFPGA(999999999) == (uint64_t)999999999000000000);
+}
+
+TEST_CASE("fromFPGA<->toFPGA", "[Timestamp]") {
+    REQUIRE(Timestamp::toFPGA(Timestamp::fromFPGA(1)) == 1);
+    REQUIRE(Timestamp::toFPGA(Timestamp::fromFPGA(33567335.12)) == 33567335);
+
+    REQUIRE(Timestamp::fromFPGA(Timestamp::toFPGA(1)) == 1);
+    REQUIRE(Timestamp::fromFPGA(Timestamp::toFPGA(33567335.12)) == 33567335.12);
+}
+
+TEST_CASE("timespecdiff", "[Timestamp]") {
+    struct timespec t1 = {1, 23000};
+    struct timespec t2 = {2, 12000};
+    REQUIRE(Timestamp::timespecdiff(&t1, &t2) == 0.999989);
+    REQUIRE(Timestamp::timespecdiff(&t2, &t1) == -0.999989);
+
+    struct timespec t3 = {99999998, 23000};
+    struct timespec t4 = {99999999, 12000};
+    REQUIRE(Timestamp::timespecdiff(&t3, &t4) == 0.999989);
+    REQUIRE(Timestamp::timespecdiff(&t4, &t3) == -0.999989);
+}

--- a/Tests/test_Timestamp.cpp
+++ b/Tests/test_Timestamp.cpp
@@ -68,15 +68,3 @@ TEST_CASE("fromFPGA<->toFPGA", "[Timestamp]") {
     REQUIRE(Timestamp::fromFPGA(Timestamp::toFPGA(1)) == 1);
     REQUIRE(Timestamp::fromFPGA(Timestamp::toFPGA(33567335.12)) == 33567335.12);
 }
-
-TEST_CASE("timespecdiff", "[Timestamp]") {
-    struct timespec t1 = {1, 23000};
-    struct timespec t2 = {2, 12000};
-    REQUIRE(Timestamp::timespecdiff(&t1, &t2) == 0.999989);
-    REQUIRE(Timestamp::timespecdiff(&t2, &t1) == -0.999989);
-
-    struct timespec t3 = {99999998, 23000};
-    struct timespec t4 = {99999999, 12000};
-    REQUIRE(Timestamp::timespecdiff(&t3, &t4) == 0.999989);
-    REQUIRE(Timestamp::timespecdiff(&t4, &t3) == -0.999989);
-}

--- a/src/LSST/M1M3/SS/Context/Context.cpp
+++ b/src/LSST/M1M3/SS/Context/Context.cpp
@@ -42,322 +42,276 @@ void Context::enterControl(EnterControlCommand* command) {
     spdlog::debug("Context: enterControl()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->enterControl(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::start(StartCommand* command) {
     spdlog::debug("Context: start()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->start(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::enable(EnableCommand* command) {
     spdlog::debug("Context: enable()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->enable(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::disable(DisableCommand* command) {
     spdlog::debug("Context: disable()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->disable(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::standby(StandbyCommand* command) {
     spdlog::debug("Context: standby()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->standby(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::exitControl(ExitControlCommand* command) {
     spdlog::debug("Context: exitControl()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->exitControl(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::update(UpdateCommand* command) {
     spdlog::trace("Context: update()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->update(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::turnAirOn(TurnAirOnCommand* command) {
     spdlog::debug("Context: turnAirOn()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->turnAirOn(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::turnAirOff(TurnAirOffCommand* command) {
     spdlog::debug("Context: turnAirOff()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->turnAirOff(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::applyOffsetForces(ApplyOffsetForcesCommand* command) {
     spdlog::debug("Context: applyOffsetForces()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->applyOffsetForces(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::clearOffsetForces(ClearOffsetForcesCommand* command) {
     spdlog::debug("Context: clearOffsetForces()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->clearOffsetForces(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::raiseM1M3(RaiseM1M3Command* command) {
     spdlog::debug("Context: raiseM1M3()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->raiseM1M3(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::lowerM1M3(LowerM1M3Command* command) {
     spdlog::debug("Context: lowerM1M3()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->lowerM1M3(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::applyAberrationForcesByBendingModes(ApplyAberrationForcesByBendingModesCommand* command) {
     spdlog::debug("Context: applyAberrationForcesByBendingModes()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->applyAberrationForcesByBendingModes(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::applyAberrationForces(ApplyAberrationForcesCommand* command) {
     spdlog::debug("Context: applyAberrationForces()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->applyAberrationForces(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::clearAberrationForces(ClearAberrationForcesCommand* command) {
     spdlog::debug("Context: clearAberrationForces()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->clearAberrationForces(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::applyActiveOpticForcesByBendingModes(ApplyActiveOpticForcesByBendingModesCommand* command) {
     spdlog::debug("Context: applyActiveOpticForcesByBendingModes()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->applyActiveOpticForcesByBendingModes(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::applyActiveOpticForces(ApplyActiveOpticForcesCommand* command) {
     spdlog::debug("Context: applyActiveOpticForces()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->applyActiveOpticForces(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::clearActiveOpticForces(ClearActiveOpticForcesCommand* command) {
     spdlog::debug("Context: clearActiveOpticForces()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->clearActiveOpticForces(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::enterEngineering(EnterEngineeringCommand* command) {
     spdlog::debug("Context: enterEngineering()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->enterEngineering(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::exitEngineering(ExitEngineeringCommand* command) {
     spdlog::debug("Context: exitEngineering()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->exitEngineering(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::testAir(TestAirCommand* command) {
     spdlog::debug("Context: testAir()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->testAir(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::testHardpoint(TestHardpointCommand* command) {
     spdlog::debug("Context: testHardpoint()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->testHardpoint(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::testForceActuator(TestForceActuatorCommand* command) {
     spdlog::debug("Context: testForceActuator()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->testForceActuator(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::moveHardpointActuators(MoveHardpointActuatorsCommand* command) {
     spdlog::debug("Context: moveHardpointActuators()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->moveHardpointActuators(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::enableHardpointChase(EnableHardpointChaseCommand* command) {
     spdlog::debug("Context: enableHardpointChase()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->enableHardpointChase(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::disableHardpointChase(DisableHardpointChaseCommand* command) {
     spdlog::debug("Context: disableHardpointChase()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->disableHardpointChase(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::abortRaiseM1M3(AbortRaiseM1M3Command* command) {
     spdlog::debug("Context: abortRaiseM1M3()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->abortRaiseM1M3(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::translateM1M3(TranslateM1M3Command* command) {
     spdlog::debug("Context: translateM1M3()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->translateM1M3(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::stopHardpointMotion(StopHardpointMotionCommand* command) {
     spdlog::debug("Context: stopHardpointMotion()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->stopHardpointMotion(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::storeTMAAzimuthSample(TMAAzimuthSampleCommand* command) {
     spdlog::debug("Context: storeTMAAzimuthSample()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->storeTMAAzimuthSample(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::storeTMAElevationSample(TMAElevationSampleCommand* command) {
     spdlog::debug("Context: storeTMAElevationSample()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->storeTMAElevationSample(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::positionM1M3(PositionM1M3Command* command) {
     spdlog::debug("Context: positionM1M3()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->positionM1M3(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::turnLightsOn(TurnLightsOnCommand* command) {
     spdlog::debug("Context: turnLightsOn()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->turnLightsOn(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::turnLightsOff(TurnLightsOffCommand* command) {
     spdlog::debug("Context: turnLightsOff()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->turnLightsOff(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::turnPowerOn(TurnPowerOnCommand* command) {
     spdlog::debug("Context: turnPowerOn()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->turnPowerOn(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::turnPowerOff(TurnPowerOffCommand* command) {
     spdlog::debug("Context: turnPowerOff()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->turnPowerOff(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::enableHardpointCorrections(EnableHardpointCorrectionsCommand* command) {
     spdlog::debug("Context: enableHardpointCorrections()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->enableHardpointCorrections(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::disableHardpointCorrections(DisableHardpointCorrectionsCommand* command) {
     spdlog::debug("Context: disableHardpointCorrections()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->disableHardpointCorrections(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::runMirrorForceProfile(RunMirrorForceProfileCommand* command) {
     spdlog::debug("Context: runMirrorForceProfile()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->runMirrorForceProfile(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::abortProfile(AbortProfileCommand* command) {
     spdlog::debug("Context: abortProfile()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->abortProfile(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::applyOffsetForcesByMirrorForce(ApplyOffsetForcesByMirrorForceCommand* command) {
     spdlog::debug("Context: applyOffsetForcesByMirrorForce()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->applyOffsetForcesByMirrorForce(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::updatePID(UpdatePIDCommand* command) {
     spdlog::debug("Context: updatePID()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->updatePID(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::resetPID(ResetPIDCommand* command) {
     spdlog::debug("Context: resetPID()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->resetPID(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::programILC(ProgramILCCommand* command) {
     spdlog::debug("Context: programILC()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->programILC(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::modbusTransmit(ModbusTransmitCommand* command) {
     spdlog::debug("Context: modbusTransmit()");
     State* state = _stateFactory->create(_currentState);
     _updateCurrentStateIfRequired(state->modbusTransmit(command, _model));
-    _stateFactory->destroy(state);
 }
 
 void Context::_updateCurrentStateIfRequired(States::Type potentialNewState) {

--- a/src/LSST/M1M3/SS/Gyro/Gyro.cpp
+++ b/src/LSST/M1M3/SS/Gyro/Gyro.cpp
@@ -33,7 +33,8 @@
 
 #include <boost/lexical_cast.hpp>
 #include <cstring>
-#include <unistd.h>
+#include <thread>
+#include <chrono>
 
 namespace LSST {
 namespace M1M3 {
@@ -60,37 +61,37 @@ Gyro::Gyro(GyroSettings* gyroSettings, M1M3SSPublisher* publisher) {
 void Gyro::bit() {
     spdlog::info("Gyro: bit()");
     this->writeCommand("?BIT,2\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::enterConfigurationMode() {
     spdlog::info("Gyro: enterConfigurationMode()");
     this->writeCommand("=CONFIG,1\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::exitConfigurationMode() {
     spdlog::info("Gyro: exitConfigurationMode()");
     this->writeCommand("=CONFIG,0\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::resetConfiguration() {
     spdlog::info("Gyro: resetConfiguration()");
     this->writeCommand("=RSTCFG\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::setRotationFormatRate() {
     spdlog::info("Gyro: setRotationFormatRate()");
     this->writeCommand("=ROTFMT,RATE\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::setRotationUnitsRadians() {
     spdlog::info("Gyro: setRotationUnitsRadians()");
     this->writeCommand("=ROTUNITS,RAD\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::setAxis() {
@@ -100,13 +101,13 @@ void Gyro::setAxis() {
         command = command + "," + boost::lexical_cast<std::string>(_gyroSettings->AxesMatrix[i]);
     }
     this->writeCommand(command + "\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::setDataRate() {
     spdlog::info("Gyro: setDataRate()");
     this->writeCommand("=DR," + boost::lexical_cast<std::string>(_gyroSettings->DataRate) + "\r\n");
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
 }
 
 void Gyro::processData() {

--- a/src/LSST/M1M3/SS/Model/Model.cpp
+++ b/src/LSST/M1M3/SS/Model/Model.cpp
@@ -214,10 +214,10 @@ void Model::publishRecommendedSettings() {
     _publisher->logSettingVersions();
 }
 
-void Model::publishOuterLoop(double executionTime) {
+void Model::publishOuterLoop(std::chrono::nanoseconds executionTime) {
     spdlog::trace("Model: publishOuterLoop()");
     MTM1M3_outerLoopDataC* data = _publisher->getOuterLoopData();
-    data->executionTime = executionTime;
+    data->executionTime = executionTime.count() / 1000000000.0;
     _publisher->putOuterLoopData();
 }
 

--- a/src/LSST/M1M3/SS/Model/Model.h
+++ b/src/LSST/M1M3/SS/Model/Model.h
@@ -46,6 +46,7 @@
 #include <ProfileController.h>
 #include <SafetyController.h>
 #include <StateTypes.h>
+#include <chrono>
 #include <pthread.h>
 #include <string>
 
@@ -83,7 +84,7 @@ public:
 
     void publishStateChange(States::Type newState);
     void publishRecommendedSettings();
-    void publishOuterLoop(double executionTime);
+    void publishOuterLoop(std::chrono::nanoseconds executionTime);
 
     void exitControl();
     void waitForExitControl();

--- a/src/LSST/M1M3/SS/Model/Model.h
+++ b/src/LSST/M1M3/SS/Model/Model.h
@@ -24,7 +24,27 @@
 #ifndef MODEL_H_
 #define MODEL_H_
 
+#include <Accelerometer.h>
+#include <AutomaticOperationsController.h>
+#include <DigitalInputOutput.h>
+#include <Displacement.h>
+#include <ForceActuatorApplicationSettings.h>
+#include <ForceActuatorSettings.h>
+#include <ForceController.h>
+#include <Gyro.h>
+#include <HardpointActuatorApplicationSettings.h>
+#include <HardpointActuatorSettings.h>
+#include <HardpointMonitorApplicationSettings.h>
+#include <Inclinometer.h>
+#include <InclinometerSettings.h>
+#include <ILC.h>
+#include <M1M3SSPublisher.h>
+#include <PIDSettings.h>
+#include <PositionController.h>
+#include <PositionControllerSettings.h>
+#include <PowerController.h>
 #include <ProfileController.h>
+#include <SafetyController.h>
 #include <StateTypes.h>
 #include <pthread.h>
 #include <string>
@@ -32,28 +52,6 @@
 namespace LSST {
 namespace M1M3 {
 namespace SS {
-
-class M1M3SSPublisher;
-class Displacement;
-class Inclinometer;
-class ILC;
-class ForceController;
-class SafetyController;
-class PositionController;
-class Accelerometer;
-class PowerController;
-class AutomaticOperationsController;
-class Gyro;
-class ForceCalculator;
-class ForceActuatorApplicationSettings;
-class ForceActuatorSettings;
-class HardpointActuatorApplicationSettings;
-class HardpointActuatorSettings;
-class HardpointMonitorApplicationSettings;
-class PIDSettings;
-class DigitalInputOutput;
-class InclinometerSettings;
-class PositionControllerSettings;
 
 class Model {
 public:

--- a/src/LSST/M1M3/SS/StateFactory/StateTypes.h
+++ b/src/LSST/M1M3/SS/StateFactory/StateTypes.h
@@ -36,8 +36,6 @@ struct States {
                        ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_StandbyState),
         DisabledState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_DisabledState) << 32) |
                         ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_DisabledState),
-        EnabledState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_EnabledState) << 32) |
-                       ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_EnabledState),
         FaultState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_FaultState) << 32) |
                      ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_FaultState),
         ParkedState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_EnabledState) << 32) |
@@ -48,8 +46,6 @@ struct States {
                       ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_ActiveState),
         LoweringState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_EnabledState) << 32) |
                         ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_LoweringState),
-        EngineeringState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_EnabledState) << 32) |
-                           ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_EngineeringState),
         ParkedEngineeringState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_EnabledState) << 32) |
                                  ((uint64_t)MTM1M3::MTM1M3_shared_DetailedStates_ParkedEngineeringState),
         RaisingEngineeringState = (((uint64_t)MTM1M3::MTM1M3_shared_SummaryStates_EnabledState) << 32) |

--- a/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.cpp
+++ b/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.cpp
@@ -88,8 +88,6 @@ State* StaticStateFactory::create(States::Type state) {
     }
 }
 
-void StaticStateFactory::destroy(State* state) { spdlog::trace("StaticStateFactory: destroy()"); }
-
 } /* namespace SS */
 } /* namespace M1M3 */
 } /* namespace LSST */

--- a/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.cpp
+++ b/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.cpp
@@ -32,12 +32,10 @@ StaticStateFactory::StaticStateFactory(M1M3SSPublisher* publisher)
         : _offlineState(publisher),
           _standbyState(publisher),
           _disabledState(publisher),
-          _enabledState(publisher),
           _parkedState(publisher),
           _raisingState(publisher),
           _activeState(publisher),
           _loweringState(publisher),
-          _engineeringState(publisher),
           _parkedEngineeringState(publisher),
           _raisingEngineeringState(publisher),
           _activeEngineeringState(publisher),
@@ -57,8 +55,6 @@ State* StaticStateFactory::create(States::Type state) {
             return &_standbyState;
         case States::DisabledState:
             return &this->_disabledState;
-        case States::EnabledState:
-            return &_enabledState;
         case States::ParkedState:
             return &_parkedState;
         case States::RaisingState:
@@ -67,8 +63,6 @@ State* StaticStateFactory::create(States::Type state) {
             return &_activeState;
         case States::LoweringState:
             return &_loweringState;
-        case States::EngineeringState:
-            return &_engineeringState;
         case States::ParkedEngineeringState:
             return &_parkedEngineeringState;
         case States::RaisingEngineeringState:

--- a/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.h
+++ b/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.h
@@ -52,7 +52,6 @@ public:
     StaticStateFactory(M1M3SSPublisher* publisher);
 
     State* create(States::Type state);
-    void destroy(State* state);
 
 private:
     OfflineState _offlineState;

--- a/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.h
+++ b/src/LSST/M1M3/SS/StateFactory/StaticStateFactory.h
@@ -27,12 +27,10 @@
 #include <OfflineState.h>
 #include <StandbyState.h>
 #include <DisabledState.h>
-#include <EnabledState.h>
 #include <ParkedState.h>
 #include <RaisingState.h>
 #include <ActiveState.h>
 #include <LoweringState.h>
-#include <EngineeringState.h>
 #include <ParkedEngineeringState.h>
 #include <RaisingEngineeringState.h>
 #include <ActiveEngineeringState.h>
@@ -57,12 +55,10 @@ private:
     OfflineState _offlineState;
     StandbyState _standbyState;
     DisabledState _disabledState;
-    EnabledState _enabledState;
     ParkedState _parkedState;
     RaisingState _raisingState;
     ActiveState _activeState;
     LoweringState _loweringState;
-    EngineeringState _engineeringState;
     ParkedEngineeringState _parkedEngineeringState;
     RaisingEngineeringState _raisingEngineeringState;
     ActiveEngineeringState _activeEngineeringState;

--- a/src/LSST/M1M3/SS/States/ActiveEngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/ActiveEngineeringState.cpp
@@ -64,10 +64,7 @@ ActiveEngineeringState::ActiveEngineeringState(M1M3SSPublisher* publisher)
 
 States::Type ActiveEngineeringState::update(UpdateCommand* command, Model* model) {
     spdlog::trace("ActiveEngineeringState: update()");
-    this->startTimer();
-    EnabledState::update(command, model);
-    this->stopTimer();
-    model->publishOuterLoop(this->getTimer());
+    sendTelemetry(model);
     return model->getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/src/LSST/M1M3/SS/States/ActiveEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/ActiveEngineeringState.h
@@ -30,6 +30,11 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Active Engineering state. Similar to Active state, mirror is raised and it's
+ * weight is supported by force actuators. This state allows execution of
+ * commands to position the mirror and change its shape.
+ */
 class ActiveEngineeringState : public EngineeringState {
 public:
     ActiveEngineeringState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/ActiveState.cpp
+++ b/src/LSST/M1M3/SS/States/ActiveState.cpp
@@ -37,10 +37,7 @@ ActiveState::ActiveState(M1M3SSPublisher* publisher) : EnabledState(publisher, "
 
 States::Type ActiveState::update(UpdateCommand* command, Model* model) {
     spdlog::trace("ActiveState: update()");
-    this->startTimer();
-    EnabledState::update(command, model);
-    this->stopTimer();
-    model->publishOuterLoop(this->getTimer());
+    sendTelemetry(model);
     return model->getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/src/LSST/M1M3/SS/States/ActiveState.h
+++ b/src/LSST/M1M3/SS/States/ActiveState.h
@@ -30,6 +30,11 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Active State. Mirror is raised, supported by force actuators. Mirror can be
+ * lowered with Lower M1M3 Command. The controller can be switched to
+ * engineering mode with Enter Engineering command.
+ */
 class ActiveState : public EnabledState {
 public:
     ActiveState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/DisabledState.cpp
+++ b/src/LSST/M1M3/SS/States/DisabledState.cpp
@@ -37,9 +37,9 @@
 #include <ModbusTransmitCommand.h>
 #include <ModelPublisher.h>
 #include <spdlog/spdlog.h>
-#include <unistd.h>
 #include <FPGA.h>
 #include <chrono>
+#include <thread>
 
 namespace LSST {
 namespace M1M3 {
@@ -54,7 +54,7 @@ States::Type DisabledState::update(UpdateCommand* command, Model* model) {
     ilc->writeFreezeSensorListBuffer();
     ilc->triggerModbus();
     model->getDigitalInputOutput()->tryToggleHeartbeat();
-    usleep(1000);
+    std::this_thread::sleep_for(1ms);
     IFPGA::get().pullTelemetry();
     model->getAccelerometer()->processData();
     model->getDigitalInputOutput()->processData();

--- a/src/LSST/M1M3/SS/States/DisabledState.cpp
+++ b/src/LSST/M1M3/SS/States/DisabledState.cpp
@@ -35,9 +35,11 @@
 #include <M1M3SSPublisher.h>
 #include <ProgramILCCommand.h>
 #include <ModbusTransmitCommand.h>
+#include <ModelPublisher.h>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 #include <FPGA.h>
+#include <chrono>
 
 namespace LSST {
 namespace M1M3 {
@@ -46,8 +48,8 @@ namespace SS {
 DisabledState::DisabledState(M1M3SSPublisher* publisher) : State(publisher, "DisabledState") {}
 
 States::Type DisabledState::update(UpdateCommand* command, Model* model) {
+    ModelPublisher publishIt(model);
     spdlog::trace("DisabledState::update()");
-    this->startTimer();
     ILC* ilc = model->getILC();
     ilc->writeFreezeSensorListBuffer();
     ilc->triggerModbus();
@@ -73,8 +75,6 @@ States::Type DisabledState::update(UpdateCommand* command, Model* model) {
     ilc->publishHardpointMonitorStatus();
     ilc->publishHardpointMonitorData();
     model->getPublisher()->tryLogHardpointActuatorWarning();
-    this->stopTimer();
-    model->publishOuterLoop(this->getTimer());
     return model->getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/src/LSST/M1M3/SS/States/DisabledState.h
+++ b/src/LSST/M1M3/SS/States/DisabledState.h
@@ -30,6 +30,11 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Disabled state. Mirror is on static supports, everything is powered off.
+ * Sends telemetry. Enable Command commands transition to Parked State.
+ * Standby Command commands transition to Standby State.
+ */
 class DisabledState : public State {
 public:
     DisabledState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/EnabledState.cpp
+++ b/src/LSST/M1M3/SS/States/EnabledState.cpp
@@ -42,12 +42,12 @@
 #include <SAL_MTM1M3C.h>
 
 #include <chrono>
+#include <thread>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-EnabledState::EnabledState(M1M3SSPublisher* publisher) : State(publisher, "EnabledState") {}
 EnabledState::EnabledState(M1M3SSPublisher* publisher, std::string name) : State(publisher, name) {}
 
 States::Type EnabledState::storeTMAAzimuthSample(TMAAzimuthSampleCommand* command, Model* model) {
@@ -82,7 +82,7 @@ void EnabledState::runLoop(Model* model) {
     ilc->writeControlListBuffer();
     ilc->triggerModbus();
     model->getDigitalInputOutput()->tryToggleHeartbeat();
-    usleep(1000);
+    std::this_thread::sleep_for(1ms);
     IFPGA::get().pullTelemetry();
     model->getAccelerometer()->processData();
     model->getDigitalInputOutput()->processData();

--- a/src/LSST/M1M3/SS/States/EnabledState.h
+++ b/src/LSST/M1M3/SS/States/EnabledState.h
@@ -32,11 +32,11 @@ namespace SS {
 
 /**
  * Parent class for all enabled sub-states. Enabled state is defined in SAL,
- * this class provides basic functionality for it.
+ * this class provides basic functionality for it. Subclasses needs to
+ * implement update method (and shall implement commands methods).
  */
 class EnabledState : public State {
 public:
-    EnabledState(M1M3SSPublisher* publisher);
     EnabledState(M1M3SSPublisher* publisher, std::string name);
 
     virtual States::Type storeTMAAzimuthSample(TMAAzimuthSampleCommand* command, Model* model) override;
@@ -44,10 +44,29 @@ public:
     virtual States::Type testAir(TestAirCommand* command, Model* model) override;
 
 protected:
+    /**
+     * Actions to be performed during a loop in enabled sub-state. Calculate
+     * forces, send updates, collects data needed for telemetry.
+     */
     void runLoop(Model* model);
+
+    /**
+     * Collects and sends telemetry.
+     */
     void sendTelemetry(Model* model);
 
+    /**
+     * Query mirror raising completion.
+     *
+     * @return true if mirror is raised
+     */
     bool raiseCompleted(Model* model);
+
+    /**
+     * Query mirror lowering completion.
+     *
+     * @return true if mirror is lowered
+     */
     bool lowerCompleted(Model* model);
 };
 

--- a/src/LSST/M1M3/SS/States/EnabledState.h
+++ b/src/LSST/M1M3/SS/States/EnabledState.h
@@ -30,15 +30,25 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Parent class for all enabled sub-states. Enabled state is defined in SAL,
+ * this class provides basic functionality for it.
+ */
 class EnabledState : public State {
 public:
     EnabledState(M1M3SSPublisher* publisher);
     EnabledState(M1M3SSPublisher* publisher, std::string name);
 
-    virtual States::Type update(UpdateCommand* command, Model* model) override;
     virtual States::Type storeTMAAzimuthSample(TMAAzimuthSampleCommand* command, Model* model) override;
     virtual States::Type storeTMAElevationSample(TMAElevationSampleCommand* command, Model* model) override;
     virtual States::Type testAir(TestAirCommand* command, Model* model) override;
+
+protected:
+    void runLoop(Model* model);
+    void sendTelemetry(Model* model);
+
+    bool raiseCompleted(Model* model);
+    bool lowerCompleted(Model* model);
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/States/EngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/EngineeringState.cpp
@@ -44,8 +44,6 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-EngineeringState::EngineeringState(M1M3SSPublisher* publisher)
-        : EnabledState(publisher, "EngineeringState") {}
 EngineeringState::EngineeringState(M1M3SSPublisher* publisher, std::string name)
         : EnabledState(publisher, name) {}
 

--- a/src/LSST/M1M3/SS/States/EngineeringState.h
+++ b/src/LSST/M1M3/SS/States/EngineeringState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Engineering state. Parent class for all engineering classes. Allows manual
+ * control of air, force actuators and hard-points.
+ */
 class EngineeringState : public EnabledState {
 public:
     EngineeringState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/EngineeringState.h
+++ b/src/LSST/M1M3/SS/States/EngineeringState.h
@@ -36,7 +36,6 @@ namespace SS {
  */
 class EngineeringState : public EnabledState {
 public:
-    EngineeringState(M1M3SSPublisher* publisher);
     EngineeringState(M1M3SSPublisher* publisher, std::string name);
 
     virtual States::Type turnAirOn(TurnAirOnCommand* command, Model* model) override;

--- a/src/LSST/M1M3/SS/States/FaultState.cpp
+++ b/src/LSST/M1M3/SS/States/FaultState.cpp
@@ -38,6 +38,7 @@
 #include <Gyro.h>
 #include <FPGA.h>
 #include <chrono>
+#include <thread>
 
 namespace LSST {
 namespace M1M3 {
@@ -53,7 +54,7 @@ States::Type FaultState::update(UpdateCommand* command, Model* model) {
     ilc->writeFreezeSensorListBuffer();
     ilc->triggerModbus();
     model->getDigitalInputOutput()->tryToggleHeartbeat();
-    usleep(1000);
+    std::this_thread::sleep_for(1ms);
     IFPGA::get().pullTelemetry();
     model->getAccelerometer()->processData();
     model->getDigitalInputOutput()->processData();

--- a/src/LSST/M1M3/SS/States/FaultState.cpp
+++ b/src/LSST/M1M3/SS/States/FaultState.cpp
@@ -32,10 +32,12 @@
 #include <ForceController.h>
 #include <unistd.h>
 #include <M1M3SSPublisher.h>
+#include <ModelPublisher.h>
 #include <Accelerometer.h>
 #include <spdlog/spdlog.h>
 #include <Gyro.h>
 #include <FPGA.h>
+#include <chrono>
 
 namespace LSST {
 namespace M1M3 {
@@ -45,8 +47,8 @@ FaultState::FaultState(M1M3SSPublisher* publisher) : State(publisher, "FaultStat
 FaultState::FaultState(M1M3SSPublisher* publisher, std::string name) : State(publisher, name) {}
 
 States::Type FaultState::update(UpdateCommand* command, Model* model) {
+    ModelPublisher publishIt(model);
     spdlog::trace("FaultState: update()");
-    this->startTimer();
     ILC* ilc = model->getILC();
     ilc->writeFreezeSensorListBuffer();
     ilc->triggerModbus();
@@ -71,8 +73,6 @@ States::Type FaultState::update(UpdateCommand* command, Model* model) {
     ilc->publishHardpointData();
     ilc->publishHardpointMonitorStatus();
     ilc->publishHardpointMonitorData();
-    this->stopTimer();
-    model->publishOuterLoop(this->getTimer());
     return States::NoStateTransition;
 }
 

--- a/src/LSST/M1M3/SS/States/FaultState.h
+++ b/src/LSST/M1M3/SS/States/FaultState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Fault state. Mirror transition to this state on any error. Accept standby
+ * command to switch to standby state.
+ */
 class FaultState : public State {
 public:
     FaultState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/LoweringEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/LoweringEngineeringState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Lowering mirror in engineering state. Doesn't allow any command except for
+ * one allowed in Engineering State.
+ */
 class LoweringEngineeringState : public EngineeringState {
 public:
     LoweringEngineeringState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/LoweringFaultState.h
+++ b/src/LSST/M1M3/SS/States/LoweringFaultState.h
@@ -34,6 +34,9 @@ class M1M3SSPublisher;
 class UpdateCommand;
 class Model;
 
+/**
+ * Lowering mirror during fault.
+ */
 class LoweringFaultState : public FaultState {
 public:
     LoweringFaultState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/LoweringState.h
+++ b/src/LSST/M1M3/SS/States/LoweringState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Lowering mirror. Mirror remains in this state until it is lowered (being
+ * supported by static support coils).
+ */
 class LoweringState : public EnabledState {
 public:
     LoweringState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/ModelPublisher.h
+++ b/src/LSST/M1M3/SS/States/ModelPublisher.h
@@ -21,24 +21,37 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <Timestamp.h>
+#ifndef MODELPUBLISHER_H_
+#define MODELPUBLISHER_H_
+
+#include <Model.h>
+
+#include <chrono>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
-namespace Timestamp {
 
-double timespecdiff(struct timespec *start, struct timespec *stop) {
-    double deltaNano = stop->tv_nsec - start->tv_nsec;
-    double deltaSec = stop->tv_sec - start->tv_sec;
-    if (deltaNano < 0) {
-        deltaSec -= 1;
-        deltaNano += NSINSEC;
+/**
+ * Measure time to acquire data and publish model data. Uses RAII-like approach to measure time it takes to
+ * execute an action, and pass elapsed time to Model::publishOuterLoop call.
+ *
+ * @see Model
+ */
+class ModelPublisher {
+public:
+    ModelPublisher(Model *model) {
+        _model = model;
+        start = std::chrono::high_resolution_clock::now();
     }
-    return deltaSec + (deltaNano / NSINSEC);
-}
+    ~ModelPublisher() { _model->publishOuterLoop(std::chrono::high_resolution_clock::now() - start); }
 
-} /* namespace Timestamp */
+private:
+    Model *_model;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+};
 } /* namespace SS */
 } /* namespace M1M3 */
 } /* namespace LSST */
+
+#endif  // MODELPUBLISHER_H_

--- a/src/LSST/M1M3/SS/States/OfflineState.cpp
+++ b/src/LSST/M1M3/SS/States/OfflineState.cpp
@@ -33,6 +33,10 @@ namespace SS {
 
 OfflineState::OfflineState(M1M3SSPublisher* publisher) : State(publisher, "OfflineState") {}
 
+States::Type OfflineState::update(UpdateCommand* command, Model* model) {
+    return rejectCommandInvalidState(command, "Update");
+}
+
 States::Type OfflineState::enterControl(EnterControlCommand* command, Model* model) {
     spdlog::info("OfflineState: enterControl()");
     model->publishRecommendedSettings();

--- a/src/LSST/M1M3/SS/States/OfflineState.h
+++ b/src/LSST/M1M3/SS/States/OfflineState.h
@@ -32,7 +32,8 @@ namespace SS {
 
 /**
  * Offline state. Only acceptable command is the enterControl command to switch
- * state to Disabled.
+ * state to StandbyState. Turns on air and mirror cell lights on transtion to
+ * StandbyState.
  */
 class OfflineState : public State {
 public:

--- a/src/LSST/M1M3/SS/States/OfflineState.h
+++ b/src/LSST/M1M3/SS/States/OfflineState.h
@@ -30,10 +30,15 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Offline state. Only acceptable command is the enterControl command to switch
+ * state to Disabled.
+ */
 class OfflineState : public State {
 public:
     OfflineState(M1M3SSPublisher* publisher);
 
+    virtual States::Type update(UpdateCommand* command, Model* model) override;
     virtual States::Type enterControl(EnterControlCommand* command, Model* model) override;
 };
 

--- a/src/LSST/M1M3/SS/States/ParkedEngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/ParkedEngineeringState.cpp
@@ -52,10 +52,7 @@ ParkedEngineeringState::ParkedEngineeringState(M1M3SSPublisher* publisher)
 
 States::Type ParkedEngineeringState::update(UpdateCommand* command, Model* model) {
     spdlog::trace("ParkedEngineeringState: update()");
-    this->startTimer();
-    EnabledState::update(command, model);
-    this->stopTimer();
-    model->publishOuterLoop(this->getTimer());
+    sendTelemetry(model);
     return model->getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/src/LSST/M1M3/SS/States/ParkedEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/ParkedEngineeringState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Parked Engineering State. Mirror can be raised, switched into Disabled State
+ * or returned to Parked State with Exit Engineering command.
+ */
 class ParkedEngineeringState : public EngineeringState {
 public:
     ParkedEngineeringState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/ParkedState.cpp
+++ b/src/LSST/M1M3/SS/States/ParkedState.cpp
@@ -42,10 +42,7 @@ ParkedState::ParkedState(M1M3SSPublisher* publisher) : EnabledState(publisher, "
 
 States::Type ParkedState::update(UpdateCommand* command, Model* model) {
     spdlog::trace("ParkedState: update()");
-    this->startTimer();
-    EnabledState::update(command, model);
-    this->stopTimer();
-    model->publishOuterLoop(this->getTimer());
+    sendTelemetry(model);
     return model->getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/src/LSST/M1M3/SS/States/ParkedState.h
+++ b/src/LSST/M1M3/SS/States/ParkedState.h
@@ -30,6 +30,11 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Parked state. Mirror is on static supports, air is on. Raise command is
+ * accepted to raise the mirror. Engineering command switch mirror to
+ * engineering state. Disable command transition mirror back to disable state.
+ */
 class ParkedState : public EnabledState {
 public:
     ParkedState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/ProfileHardpointCorrectionState.cpp
+++ b/src/LSST/M1M3/SS/States/ProfileHardpointCorrectionState.cpp
@@ -34,7 +34,7 @@ namespace M1M3 {
 namespace SS {
 
 ProfileHardpointCorrectionState::ProfileHardpointCorrectionState(M1M3SSPublisher* publisher)
-        : EnabledState(publisher, "LoweringFaultState") {}
+        : EnabledState(publisher, "ProfileHardpointCorrectionState") {}
 
 States::Type ProfileHardpointCorrectionState::update(UpdateCommand* command, Model* model) {
     spdlog::trace("ProfileHardpointCorrectionState: update()");

--- a/src/LSST/M1M3/SS/States/ProfileHardpointCorrectionState.cpp
+++ b/src/LSST/M1M3/SS/States/ProfileHardpointCorrectionState.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <ProfileHardpointCorrectionState.h>
-#include <Model.h>
 #include <ForceController.h>
 #include <ProfileController.h>
 #include <MirrorForceProfile.h>
@@ -41,7 +40,7 @@ States::Type ProfileHardpointCorrectionState::update(UpdateCommand* command, Mod
     MirrorForceProfileRecord force = model->getProfileController()->getMirrorForceProfileData();
     model->getForceController()->applyOffsetForcesByMirrorForces(force.XForce, force.YForce, force.ZForce,
                                                                  force.XMoment, force.YMoment, force.ZMoment);
-    EnabledState::update(command, model);
+    sendTelemetry(model);
     if (model->getProfileController()->incMirrorForceProfile()) {
         return model->getSafetyController()->checkSafety(States::ActiveEngineeringState);
     }

--- a/src/LSST/M1M3/SS/States/RaisingEngineeringState.h
+++ b/src/LSST/M1M3/SS/States/RaisingEngineeringState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Raises mirror in engineering state. Transition to ActiveEngineering on raise
+ * completed, or Lowering Engineering state on abort.
+ */
 class RaisingEngineeringState : public EngineeringState {
 public:
     RaisingEngineeringState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/RaisingState.h
+++ b/src/LSST/M1M3/SS/States/RaisingState.h
@@ -30,6 +30,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * State during mirror raise. Transition to active state when raise finished,
+ * or to lowering state on abort.
+ */
 class RaisingState : public EnabledState {
 public:
     RaisingState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/StandbyState.cpp
+++ b/src/LSST/M1M3/SS/States/StandbyState.cpp
@@ -30,8 +30,9 @@
 #include <StartCommand.h>
 #include <Gyro.h>
 #include <M1M3SSPublisher.h>
-#include <unistd.h>
 
+#include <thread>
+#include <chrono>
 #include <spdlog/spdlog.h>
 
 namespace LSST {
@@ -58,7 +59,7 @@ States::Type StandbyState::start(StartCommand* command, Model* model) {
     powerController->setAllPowerNetworks(true);
     for (int i = 0; i < 2; ++i) {
         digitalInputOutput->tryToggleHeartbeat();
-        usleep(500000);
+        std::this_thread::sleep_for(500ms);
     }
 
     ilc->flushAll();
@@ -108,7 +109,7 @@ States::Type StandbyState::start(StartCommand* command, Model* model) {
     ilc->readAll();
     digitalInputOutput->tryToggleHeartbeat();
     model->getPublisher()->tryLogForceActuatorState();
-    usleep(20000);
+    std::this_thread::sleep_for(20ms);
     ilc->verifyResponses();
     ilc->publishForceActuatorInfo();
     ilc->publishHardpointActuatorInfo();

--- a/src/LSST/M1M3/SS/States/StandbyState.h
+++ b/src/LSST/M1M3/SS/States/StandbyState.h
@@ -30,6 +30,11 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * State between Offline and Enabled sub-states. Transition to Offline State on
+ * exitControll command and to Parked State (Enabled Sub-state) on start
+ * command.
+ */
 class StandbyState : public State {
 public:
     StandbyState(M1M3SSPublisher* publisher);

--- a/src/LSST/M1M3/SS/States/State.cpp
+++ b/src/LSST/M1M3/SS/States/State.cpp
@@ -55,7 +55,6 @@ States::Type State::standby(StandbyCommand* command, Model* model) {
 States::Type State::exitControl(ExitControlCommand* command, Model* model) {
     return this->rejectCommandInvalidState(command, "ExitControl");
 }
-States::Type State::update(UpdateCommand* command, Model* model) { return States::NoStateTransition; }
 States::Type State::turnAirOn(TurnAirOnCommand* command, Model* model) {
     return this->rejectCommandInvalidState(command, "TurnAirOn");
 }
@@ -176,18 +175,6 @@ States::Type State::programILC(ProgramILCCommand* command, Model* model) {
 States::Type State::modbusTransmit(ModbusTransmitCommand* command, Model* model) {
     return this->rejectCommandInvalidState(command, "ModbusTransmit");
 }
-
-void State::startTimer() { clock_gettime(CLOCK_REALTIME, &this->startTime); }
-
-void State::stopTimer() { clock_gettime(CLOCK_REALTIME, &this->stopTime); }
-
-double State::getCurrentTimer() {
-    timespec now;
-    clock_gettime(CLOCK_REALTIME, &now);
-    return Timestamp::timespecdiff(&startTime, &now);
-}
-
-double State::getTimer() { return Timestamp::timespecdiff(&startTime, &stopTime); }
 
 States::Type State::rejectCommandInvalidState(Command* command, std::string cmd_name) {
     std::string reason = "The command " + cmd_name + " is not valid in the " + this->name + ".";

--- a/src/LSST/M1M3/SS/States/State.cpp
+++ b/src/LSST/M1M3/SS/States/State.cpp
@@ -23,6 +23,7 @@
 
 #include <State.h>
 #include <DataTypes.h>
+#include <Timestamp.h>
 #include <spdlog/spdlog.h>
 
 namespace LSST {
@@ -183,24 +184,10 @@ void State::stopTimer() { clock_gettime(CLOCK_REALTIME, &this->stopTime); }
 double State::getCurrentTimer() {
     timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
-    double deltaNano = now.tv_nsec - this->startTime.tv_nsec;
-    double deltaSec = now.tv_sec - this->startTime.tv_sec;
-    if (deltaNano < 0) {
-        deltaSec -= 1;
-        deltaNano += 1000000000;
-    }
-    return deltaSec + (deltaNano / 1000000000.0);
+    return Timestamp::timespecdiff(&startTime, &now);
 }
 
-double State::getTimer() {
-    double deltaNano = this->stopTime.tv_nsec - this->startTime.tv_nsec;
-    double deltaSec = this->stopTime.tv_sec - this->startTime.tv_sec;
-    if (deltaNano < 0) {
-        deltaSec -= 1;
-        deltaNano += 1000000000;
-    }
-    return deltaSec + (deltaNano / 1000000000.0);
-}
+double State::getTimer() { return Timestamp::timespecdiff(&startTime, &stopTime); }
 
 States::Type State::rejectCommandInvalidState(Command* command, std::string cmd_name) {
     std::string reason = "The command " + cmd_name + " is not valid in the " + this->name + ".";

--- a/src/LSST/M1M3/SS/States/State.h
+++ b/src/LSST/M1M3/SS/States/State.h
@@ -82,13 +82,12 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
+/**
+ * Abstract class for M1M3 state. Any M1M3 state should inherit this class and
+ * implements command functions it executed. Calls to functions not implemented
+ * for the state shall be rejected.
+ */
 class State {
-protected:
-    M1M3SSPublisher* publisher;
-    std::string name;
-    timespec startTime;
-    timespec stopTime;
-
 public:
     State(M1M3SSPublisher* publisher, std::string name);
     virtual ~State();
@@ -99,7 +98,7 @@ public:
     virtual States::Type disable(DisableCommand* command, Model* model);
     virtual States::Type standby(StandbyCommand* command, Model* model);
     virtual States::Type exitControl(ExitControlCommand* command, Model* model);
-    virtual States::Type update(UpdateCommand* command, Model* model);
+    virtual States::Type update(UpdateCommand* command, Model* model) = 0;
     virtual States::Type turnAirOn(TurnAirOnCommand* command, Model* model);
     virtual States::Type turnAirOff(TurnAirOffCommand* command, Model* model);
     virtual States::Type applyOffsetForces(ApplyOffsetForcesCommand* command, Model* model);
@@ -145,10 +144,8 @@ public:
     virtual States::Type modbusTransmit(ModbusTransmitCommand* command, Model* model);
 
 protected:
-    void startTimer();
-    void stopTimer();
-    double getCurrentTimer();
-    double getTimer();
+    M1M3SSPublisher* publisher;
+    std::string name;
 
     States::Type rejectCommandInvalidState(Command* command, std::string cmd_name);
 };

--- a/src/LSST/M1M3/SS/Threads/ControllerThread.cpp
+++ b/src/LSST/M1M3/SS/Threads/ControllerThread.cpp
@@ -23,8 +23,11 @@
 
 #include <ControllerThread.h>
 #include <Controller.h>
-#include <unistd.h>
+#include <chrono>
+#include <thread>
 #include <spdlog/spdlog.h>
+
+using namespace std::chrono_literals;
 
 namespace LSST {
 namespace M1M3 {
@@ -44,7 +47,7 @@ void ControllerThread::run() {
         if (command) {
             _controller->execute(command);
         } else {
-            usleep(100);
+            std::this_thread::sleep_for(100us);
         }
     }
     spdlog::info("ControllerThread: Completed");

--- a/src/LSST/M1M3/SS/Threads/SubscriberThread.cpp
+++ b/src/LSST/M1M3/SS/Threads/SubscriberThread.cpp
@@ -27,7 +27,8 @@
 #include <M1M3SSPublisher.h>
 #include <CommandFactory.h>
 #include <Command.h>
-#include <unistd.h>
+#include <chrono>
+#include <thread>
 #include <spdlog/spdlog.h>
 
 namespace LSST {
@@ -90,7 +91,7 @@ void SubscriberThread::run() {
         _enqueueCommandIfAvailable(_subscriber->tryAcceptCommandModbusTransmit());
         _enqueueCommandIfAvailable(_subscriber->tryGetSampleTMAAzimuth());
         _enqueueCommandIfAvailable(_subscriber->tryGetSampleTMAElevation());
-        usleep(100);
+        std::this_thread::sleep_for(100us);
     }
     spdlog::info("SubscriberThread: Completed");
 }

--- a/src/LSST/M1M3/SS/Utility/Timestamp.cpp
+++ b/src/LSST/M1M3/SS/Utility/Timestamp.cpp
@@ -1,0 +1,44 @@
+/*
+ * This file is part of LSST M1M3 support system package.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <Timestamp.h>
+
+namespace LSST {
+namespace M1M3 {
+namespace SS {
+namespace Timestamp {
+
+double timespecdiff(struct timespec *start, struct timespec *stop) {
+    double deltaNano = stop->tv_nsec - start->tv_nsec;
+    double deltaSec = stop->tv_sec - start->tv_sec;
+    if (deltaNano < 0) {
+        deltaSec -= 1;
+        deltaNano += NSINSEC;
+    }
+    return deltaSec + (deltaNano / NSINSEC);
+}
+
+} /* namespace Timestamp */
+} /* namespace SS */
+} /* namespace M1M3 */
+} /* namespace LSST */

--- a/src/LSST/M1M3/SS/Utility/Timestamp.h
+++ b/src/LSST/M1M3/SS/Utility/Timestamp.h
@@ -25,21 +25,60 @@
 #define TIMESTAMP_H_
 
 #include <DataTypes.h>
+#include <sys/time.h>
 
 namespace LSST {
 namespace M1M3 {
 namespace SS {
+/**
+ * Utility functions for time manipulations.
+ */
+namespace Timestamp {
+const uint64_t NSINSEC = 1000000000;  //* seconds in nanosecond
+/**
+ * Converts raw (nanoseconds) timestamp into seconds.
+ *
+ * @param raw raw value (nanoseconds)
+ *
+ * @return seconds
+ */
+inline double fromRaw(uint64_t raw) { return ((double)raw) / NSINSEC; }
 
-class Timestamp {
-public:
-    static double fromRaw(uint64_t raw) { return ((double)raw) / 1000000000.0; }
-    static uint64_t toRaw(double timestamp) { return (uint64_t)(timestamp * 1000000000.0); }
-    static uint64_t toFPGA(double timestamp) { return (uint64_t)(timestamp * 1000000000.0); }
-    static double fromFPGA(uint64_t timestamp) { return ((double)timestamp) / 1000000000.0; }
-};
+/**
+ * Converts seconds into raw value (nanoseconds).
+ *
+ * @param timestamp value (seconds)
+ *
+ * @return raw value (nanoseconds)
+ */
+inline uint64_t toRaw(double timestamp) { return (uint64_t)(timestamp * (double)NSINSEC); }
 
-} /* namespace SS */
-} /* namespace M1M3 */
-} /* namespace LSST */
+/**
+ * Converts FPGA (nanoseconds) timestamp into seconds.
+ *
+ * @param raw FPGA value (nanoseconds)
+ *
+ * @return seconds
+ */
+inline double fromFPGA(uint64_t timestamp) { return ((double)timestamp) / NSINSEC; }
+
+/**
+ * Converts seconds into FPGA value (nanoseconds).
+ *
+ * @param timestamp value (seconds)
+ *
+ * @return FPGA value (nanoseconds)
+ */
+inline uint64_t toFPGA(double timestamp) { return (uint64_t)(timestamp * (double)NSINSEC); }
+
+/**
+ * Returns difference (in seconds) between two timespec structures.
+ */
+double timespecdiff(struct timespec *start, struct timespec *stop);
+}  // namespace Timestamp
+
+}  // namespace SS
+}  // namespace M1M3
+}  // namespace LSST
 
 #endif /* TIMESTAMP_H_ */

--- a/src/LSST/M1M3/SS/Utility/Timestamp.h
+++ b/src/LSST/M1M3/SS/Utility/Timestamp.h
@@ -70,11 +70,6 @@ inline double fromFPGA(uint64_t timestamp) { return ((double)timestamp) / NSINSE
  * @return FPGA value (nanoseconds)
  */
 inline uint64_t toFPGA(double timestamp) { return (uint64_t)(timestamp * (double)NSINSEC); }
-
-/**
- * Returns difference (in seconds) between two timespec structures.
- */
-double timespecdiff(struct timespec *start, struct timespec *stop);
 }  // namespace Timestamp
 
 }  // namespace SS

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,9 +68,9 @@ clean:
 	${co}$(C) -c -fmessage-length=0 -o $@ $<
 
 %.cpp.d: %.cpp
-	@echo '[DPP] $^'
-	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$*.o $*.cpp.d'
+	@echo '[DPP] $<'
+	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$(patsubst %.cpp,%.o,$<)'
 
 %.c.d: %.c
 	@echo '[DEP] $^'
-	${co}$(C) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$*.o $*.c.d'
+	${co}$(C) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$(patsubst %.c,%.o,$<)'

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,8 +69,8 @@ clean:
 
 %.cpp.d: %.cpp
 	@echo '[DPP] $<'
-	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$(patsubst %.cpp,%.o,$<)'
+	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $< -MF $@ -MT '$(patsubst %.cpp,%.o,$<) $@'
 
 %.c.d: %.c
 	@echo '[DEP] $^'
-	${co}$(C) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$(patsubst %.c,%.o,$<)'
+	${co}$(C) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $< -MF $@ -MT '$(patsubst %.c,%.o,$<) $@'

--- a/src/ts_M1M3Support.cpp
+++ b/src/ts_M1M3Support.cpp
@@ -20,6 +20,9 @@
 #include <cstring>
 #include <iostream>
 
+#include <chrono>
+#include <thread>
+
 #include <spdlog/spdlog.h>
 #include <spdlog/async.h>
 #include "spdlog/sinks/stdout_color_sinks.h"
@@ -166,7 +169,7 @@ void runFPGAs(M1M3SSPublisher* publisher, std::shared_ptr<SAL_MTM1M3> m1m3SAL,
     void* status;
     spdlog::info("Main: Starting pps thread");
     int rc = pthread_create(&ppsThreadId, &threadAttribute, runThread, (void*)(&ppsThread));
-    usleep(1500000);
+    std::this_thread::sleep_for(1500ms);
     if (!rc) {
         spdlog::info("Main: Starting subscriber thread");
         int rc = pthread_create(&subscriberThreadId, &threadAttribute, runThread, (void*)(&subscriberThread));
@@ -189,7 +192,7 @@ void runFPGAs(M1M3SSPublisher* publisher, std::shared_ptr<SAL_MTM1M3> m1m3SAL,
                     controllerThread.stop();
                     spdlog::info("Main: Stopping outer loop clock thread");
                     outerLoopClockThread.stop();
-                    usleep(100000);
+                    std::this_thread::sleep_for(100ms);
                     controller.clear();
                     spdlog::info("Main: Joining pps thread");
                     pthread_join(ppsThreadId, &status);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,6 @@ all: compile
 TEST_SRCS := $(shell ls test_*.cpp 2>/dev/null)
 BINARIES := $(patsubst %.cpp,%,$(TEST_SRCS))
 DEPS := $(patsubst %.cpp,%.cpp.d,$(TEST_SRCS))
-OBJS := $(patsubst %.cpp,%.o,$(TEST_SRCS))
 JUNIT_FILES := $(shell ls *.xml 2>/dev/null)
 
 ifneq ($(MAKECMDGOALS),clean)
@@ -60,14 +59,14 @@ junit: compile
 	@$(foreach b,$(BINARIES),echo '[JUT] ${b}'; ./${b} -r junit -o ${b}.xml;)
 
 clean:
-	@$(foreach df,$(BINARIES) $(DEPS) $(OBJS) $(JUNIT_FILES),echo '[RM ] ${df}'; $(RM) ${df};)
+	@$(foreach df,$(BINARIES) $(DEPS) $(JUNIT_FILES),echo '[RM ] ${df}'; $(RM) ${df};)
 
 ../src/libM1M3SS.a: FORCE
 	@$(MAKE) -C ../src libM1M3SS.a SIMULATOR=1
 
 %.cpp.d: %.cpp
 	@echo '[DEP] $<'
-	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@
+	${co}$(CPP) $(BOOST_CPPFLAGS) $(SAL_CPPFLAGS) $(M1M3_CPPFLAGS) -M $^ -MF $@ -MT '$*.o $*.cpp.d'
 
 %: %.cpp ../src/libM1M3SS.a
 	@echo '[TPP] $<'


### PR DESCRIPTION
Document M1M3 states and their purposes. Streamline states hieararchy by making
non-instantiated states (Enabled, Engineering) abstract. Make update method
(responding to Update Command) pure virtual to enforce its overwrite in child
classes.

RAII-approach for measuring time to process command and send data in update
method. Added runLoop and sendTelemetry methods to EnableState, replacing
update method & its calls from children. This better express what those methods
provide.

Use C++14 chrono literals and C++11 chrono and thread functions instead of
usleep.