### PR TITLE
Jenkins noCache parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,11 @@ properties(
             daysToKeepStr: '14',
             numToKeepStr: ''
         ) ),
-    disableConcurrentBuilds()
+    disableConcurrentBuilds(),
+    parameters
+        ( [
+            booleanParam(defaultValue: false, description: 'Adds --no-cache to Docker build command', name: 'noCache')
+        ] )
     ]
 )
 
@@ -30,7 +34,7 @@ node {
 
     stage('Building dev container')
     {
-        M1M3sim = docker.build("lsstts/mtm1m3_sim:" + env.BRANCH_NAME.replace("/", "_"), "--target lsstts-cpp-dev ts_Dockerfiles/mtm1m3_sim")
+        M1M3sim = docker.build("lsstts/mtm1m3_sim:" + env.BRANCH_NAME.replace("/", "_"), (params.noCache ? "--no-cache " : " ") + "--target lsstts-cpp-dev ts_Dockerfiles/mtm1m3_sim")
     }
 
     stage('Cloning source')


### PR DESCRIPTION
Triggers container builds with --no-cache option. Usefull when XML schema changes and salgenerator needs to be run - without the option, if the container is already cached, the script will not run salgenerator during container build.