### PR TITLE
startup->EnterControl (documentation fix)

### DIFF
--- a/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
+++ b/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
@@ -515,7 +515,7 @@ void SimulatedFPGA::writeCommandFIFO(uint16_t* data, int32_t length, int32_t tim
                                            1000.0) +
                                           (_getRnd() * 0.5);  // Update to Primary Cylinder Force
                             // uncomment to simulate follow up error
-                            if (subnet == 1 && address == 17 && force > 500) force = 200;
+                            // if (subnet == 1 && address == 17 && force > 500) force = 200;
                             memcpy(buffer, &force, 4);
                             _writeModbus(response, buffer[3]);
                             _writeModbus(response, buffer[2]);

--- a/src/LSST/M1M3/SS/States/dir.dox
+++ b/src/LSST/M1M3/SS/States/dir.dox
@@ -44,7 +44,7 @@
  *     Standby [URL="@ref LSST::M1M3::SS::StandbyState"];
  *     Disabled [URL="@ref LSST::M1M3::SS::DisabledState"];
  *
- *     Offline -> Standby [label="startup"];
+ *     Offline -> Standby [label="EnterControl"];
  *     Standby -> Offline [label="ExitControl",URL="@ref LSST::M1M3::SS::ExitControlCommand"];
  *     Standby -> Disabled [label="Start",URL="@ref LSST::M1M3::SS::StartCommand"];
  *     Disabled -> Standby [label="Standby",URL="@ref LSST::M1M3::SS::StandbyCommand"];


### PR DESCRIPTION
startup command was renamed to EnterControl, comment out test line in FPGA simulator