### PR TITLE
fault the mirror when hardpoint limits are hit

### DIFF
--- a/src/LSST/M1M3/SS/Controllers/ForceController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/ForceController.cpp
@@ -45,27 +45,22 @@ using namespace std;
 using namespace LSST::M1M3::SS;
 
 ForceController::ForceController(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
-                                 ForceActuatorSettings* forceActuatorSettings, PIDSettings* pidSettings,
-                                 SafetyController* safetyController)
-        : _aberrationForceComponent(safetyController, forceActuatorApplicationSettings,
-                                    forceActuatorSettings),
-          _accelerationForceComponent(safetyController, forceActuatorApplicationSettings,
-                                      forceActuatorSettings),
-          _activeOpticForceComponent(safetyController, forceActuatorApplicationSettings,
-                                     forceActuatorSettings),
-          _azimuthForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings),
-          _balanceForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings,
-                                 pidSettings),
-          _elevationForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings),
-          _offsetForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings),
-          _staticForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings),
-          _thermalForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings),
-          _velocityForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings),
-          _finalForceComponent(safetyController, forceActuatorApplicationSettings, forceActuatorSettings) {
+                                 ForceActuatorSettings* forceActuatorSettings, PIDSettings* pidSettings)
+        : _aberrationForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _accelerationForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _activeOpticForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _azimuthForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _balanceForceComponent(forceActuatorApplicationSettings, forceActuatorSettings, pidSettings),
+          _elevationForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _offsetForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _staticForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _thermalForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _velocityForceComponent(forceActuatorApplicationSettings, forceActuatorSettings),
+          _finalForceComponent(forceActuatorApplicationSettings, forceActuatorSettings) {
     SPDLOG_DEBUG("ForceController: ForceController()");
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _pidSettings = pidSettings;
 
     _appliedCylinderForces = M1M3SSPublisher::get().getEventAppliedCylinderForces();

--- a/src/LSST/M1M3/SS/Controllers/ForceController.h
+++ b/src/LSST/M1M3/SS/Controllers/ForceController.h
@@ -131,8 +131,7 @@ struct ForceActuatorIndicesNeighbors {
 class ForceController {
 public:
     ForceController(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
-                    ForceActuatorSettings* forceActuatorSettings, PIDSettings* pidSettings,
-                    SafetyController* safetyController);
+                    ForceActuatorSettings* forceActuatorSettings, PIDSettings* pidSettings);
 
     void reset();
 

--- a/src/LSST/M1M3/SS/Controllers/PositionController.h
+++ b/src/LSST/M1M3/SS/Controllers/PositionController.h
@@ -28,6 +28,7 @@
 #include <Units.h>
 #include <HardpointActuatorSettings.h>
 #include <PositionControllerSettings.h>
+#include <SafetyController.h>
 #include <SAL_MTM1M3C.h>
 
 namespace LSST {
@@ -138,6 +139,11 @@ public:
      */
     void updateSteps();
 
+    /**
+     * Check the hardpoint doesn't try to move past limits.
+     */
+    void checkLimits(int hp);
+
 private:
     void _convertToSteps(int32_t* steps, double x, double y, double z, double rX, double rY, double rZ);
 
@@ -146,11 +152,14 @@ private:
 
     MTM1M3_hardpointActuatorDataC* _hardpointActuatorData;
     MTM1M3_logevent_hardpointActuatorStateC* _hardpointActuatorState;
+    MTM1M3_logevent_hardpointActuatorWarningC* _hardpointActuatorWarning;
     MTM1M3_logevent_hardpointActuatorInfoC* _hardpointInfo;
 
     int32_t _scaledMaxStepsPerLoop[6];
     int32_t _targetEncoderValues[6];
     int32_t _stableEncoderCount[6];
+
+    SafetyController* _safetyController;
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
@@ -56,6 +56,9 @@ SafetyController::SafetyController(SafetyControllerSettings* safetyControllerSet
             _hardpointActuatorAirPressureData[j].push_back(0);
         }
     }
+    for (int i = 0; i < HP_COUNT; i++) {
+        _hardpointLimitTriggered[i] = false;
+    }
 }
 
 void SafetyController::clearErrorCode() {
@@ -370,6 +373,38 @@ void SafetyController::forceControllerNotifyForceClipping(bool conditionFlag) {
     _updateOverride(FaultCodes::ForceControllerForceClipping,
                     _safetyControllerSettings->ForceController.FaultOnForceClipping, conditionFlag,
                     "Force controller force clipping");
+}
+
+void SafetyController::positionControllerNotifyLimitLow(int hp, bool conditionFlag) {
+    if (conditionFlag) {
+        if (_hardpointLimitTriggered[hp] == false) {
+            _updateOverride(FaultCodes::HardpointActuatorLimitLowError, true, conditionFlag,
+                            "Hardpoint #{} hit low limit", hp);
+            _hardpointLimitTriggered[hp] = true;
+        }
+
+    } else {
+        if (_hardpointLimitTriggered[hp] == true) {
+            SPDLOG_INFO("Hardpoint #{} low limit cleared", hp);
+            _hardpointLimitTriggered[hp] = false;
+        }
+    }
+}
+
+void SafetyController::positionControllerNotifyLimitHigh(int hp, bool conditionFlag) {
+    if (conditionFlag) {
+        if (_hardpointLimitTriggered[hp] == false) {
+            _updateOverride(FaultCodes::HardpointActuatorLimitHighError, true, conditionFlag,
+                            "Hardpoint #{} hit high limit", hp);
+            _hardpointLimitTriggered[hp] = true;
+        }
+
+    } else {
+        if (_hardpointLimitTriggered[hp] == true) {
+            SPDLOG_INFO("Hardpoint #{} high limit cleared", hp);
+            _hardpointLimitTriggered[hp] = false;
+        }
+    }
 }
 
 void SafetyController::cellLightNotifyOutputMismatch(bool conditionFlag) {

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
@@ -57,7 +57,8 @@ SafetyController::SafetyController(SafetyControllerSettings* safetyControllerSet
         }
     }
     for (int i = 0; i < HP_COUNT; i++) {
-        _hardpointLimitTriggered[i] = false;
+        _hardpointLimitLowTriggered[i] = false;
+        _hardpointLimitHighTriggered[i] = false;
     }
 }
 
@@ -377,32 +378,32 @@ void SafetyController::forceControllerNotifyForceClipping(bool conditionFlag) {
 
 void SafetyController::positionControllerNotifyLimitLow(int hp, bool conditionFlag) {
     if (conditionFlag) {
-        if (_hardpointLimitTriggered[hp] == false) {
+        if (_hardpointLimitLowTriggered[hp] == false) {
             _updateOverride(FaultCodes::HardpointActuatorLimitLowError, true, conditionFlag,
                             "Hardpoint #{} hit low limit", hp);
-            _hardpointLimitTriggered[hp] = true;
+            _hardpointLimitLowTriggered[hp] = true;
         }
 
     } else {
-        if (_hardpointLimitTriggered[hp] == true) {
+        if (_hardpointLimitLowTriggered[hp] == true) {
             SPDLOG_INFO("Hardpoint #{} low limit cleared", hp);
-            _hardpointLimitTriggered[hp] = false;
+            _hardpointLimitLowTriggered[hp] = false;
         }
     }
 }
 
 void SafetyController::positionControllerNotifyLimitHigh(int hp, bool conditionFlag) {
     if (conditionFlag) {
-        if (_hardpointLimitTriggered[hp] == false) {
+        if (_hardpointLimitHighTriggered[hp] == false) {
             _updateOverride(FaultCodes::HardpointActuatorLimitHighError, true, conditionFlag,
                             "Hardpoint #{} hit high limit", hp);
-            _hardpointLimitTriggered[hp] = true;
+            _hardpointLimitHighTriggered[hp] = true;
         }
 
     } else {
-        if (_hardpointLimitTriggered[hp] == true) {
+        if (_hardpointLimitHighTriggered[hp] == true) {
             SPDLOG_INFO("Hardpoint #{} high limit cleared", hp);
-            _hardpointLimitTriggered[hp] = false;
+            _hardpointLimitHighTriggered[hp] = false;
         }
     }
 }

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.h
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.h
@@ -108,6 +108,9 @@ public:
     void forceControllerNotifyVelocityForceClipping(bool conditionFlag);
     void forceControllerNotifyForceClipping(bool conditionFlag);
 
+    void positionControllerNotifyLimitLow(int hp, bool conditionFlag);
+    void positionControllerNotifyLimitHigh(int hp, bool conditionFlag);
+
     void cellLightNotifyOutputMismatch(bool conditionFlag);
     void cellLightNotifySensorMismatch(bool conditionFlag);
 
@@ -179,6 +182,7 @@ private:
     std::list<int> _forceActuatorFollowingErrorData[FA_COUNT];
     std::list<int> _hardpointActuatorMeasuredForceData[HP_COUNT];
     std::list<int> _hardpointActuatorAirPressureData[HP_COUNT];
+    bool _hardpointLimitTriggered[HP_COUNT];
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.h
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.h
@@ -182,7 +182,8 @@ private:
     std::list<int> _forceActuatorFollowingErrorData[FA_COUNT];
     std::list<int> _hardpointActuatorMeasuredForceData[HP_COUNT];
     std::list<int> _hardpointActuatorAirPressureData[HP_COUNT];
-    bool _hardpointLimitTriggered[HP_COUNT];
+    bool _hardpointLimitLowTriggered[HP_COUNT];
+    bool _hardpointLimitHighTriggered[HP_COUNT];
 };
 
 } /* namespace SS */

--- a/src/LSST/M1M3/SS/ForceComponents/AberrationForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/AberrationForceComponent.cpp
@@ -23,7 +23,7 @@
 
 #include <AberrationForceComponent.h>
 #include <M1M3SSPublisher.h>
-#include <SafetyController.h>
+#include <Model.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
 #include <Range.h>
@@ -37,11 +37,10 @@ namespace M1M3 {
 namespace SS {
 
 AberrationForceComponent::AberrationForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Aberration", forceActuatorSettings->AberrationComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/AberrationForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/AberrationForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class AberrationForceComponent : public ForceComponent {
 public:
-    AberrationForceComponent(SafetyController* safetyController,
-                             ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    AberrationForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                              ForceActuatorSettings* forceActuatorSettings);
 
     void applyAberrationForces(float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/AccelerationForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/AccelerationForceComponent.cpp
@@ -23,7 +23,7 @@
 
 #include <AccelerationForceComponent.h>
 #include <M1M3SSPublisher.h>
-#include <SafetyController.h>
+#include <Model.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
 #include <Range.h>
@@ -37,11 +37,10 @@ namespace M1M3 {
 namespace SS {
 
 AccelerationForceComponent::AccelerationForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Acceleration", forceActuatorSettings->AccelerationComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/AccelerationForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/AccelerationForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class AccelerationForceComponent : public ForceComponent {
 public:
-    AccelerationForceComponent(SafetyController* safetyController,
-                               ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    AccelerationForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                                ForceActuatorSettings* forceActuatorSettings);
 
     void applyAccelerationForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/ActiveOpticForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/ActiveOpticForceComponent.cpp
@@ -23,7 +23,7 @@
 
 #include <ActiveOpticForceComponent.h>
 #include <M1M3SSPublisher.h>
-#include <SafetyController.h>
+#include <Model.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
 #include <Range.h>
@@ -37,11 +37,10 @@ namespace M1M3 {
 namespace SS {
 
 ActiveOpticForceComponent::ActiveOpticForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("ActiveOptic", forceActuatorSettings->ActiveOpticComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/ActiveOpticForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/ActiveOpticForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class ActiveOpticForceComponent : public ForceComponent {
 public:
-    ActiveOpticForceComponent(SafetyController* safetyController,
-                              ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    ActiveOpticForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                               ForceActuatorSettings* forceActuatorSettings);
 
     void applyActiveOpticForces(float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/AzimuthForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/AzimuthForceComponent.cpp
@@ -23,7 +23,7 @@
 
 #include <AzimuthForceComponent.h>
 #include <M1M3SSPublisher.h>
-#include <SafetyController.h>
+#include <Model.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
 #include <Range.h>
@@ -38,11 +38,10 @@ namespace M1M3 {
 namespace SS {
 
 AzimuthForceComponent::AzimuthForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Azimuth", forceActuatorSettings->AzimuthComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/AzimuthForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/AzimuthForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class AzimuthForceComponent : public ForceComponent {
 public:
-    AzimuthForceComponent(SafetyController* safetyController,
-                          ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    AzimuthForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                           ForceActuatorSettings* forceActuatorSettings);
 
     void applyAzimuthForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/BalanceForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/BalanceForceComponent.cpp
@@ -23,7 +23,7 @@
 
 #include <BalanceForceComponent.h>
 #include <M1M3SSPublisher.h>
-#include <SafetyController.h>
+#include <Model.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
 #include <PIDSettings.h>
@@ -38,7 +38,6 @@ namespace M1M3 {
 namespace SS {
 
 BalanceForceComponent::BalanceForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings, PIDSettings* pidSettings)
         : ForceComponent("Balance", forceActuatorSettings->BalanceComponentSettings),
@@ -48,7 +47,7 @@ BalanceForceComponent::BalanceForceComponent(
           _mx(3, pidSettings->getParameters(3)),
           _my(4, pidSettings->getParameters(4)),
           _mz(5, pidSettings->getParameters(5)) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _pidSettings = pidSettings;

--- a/src/LSST/M1M3/SS/ForceComponents/BalanceForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/BalanceForceComponent.h
@@ -54,8 +54,7 @@ namespace SS {
  */
 class BalanceForceComponent : public ForceComponent {
 public:
-    BalanceForceComponent(SafetyController* safetyController,
-                          ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    BalanceForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                           ForceActuatorSettings* forceActuatorSettings, PIDSettings* pidSettings);
 
     void applyBalanceForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/ElevationForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/ElevationForceComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <ElevationForceComponent.h>
 #include <M1M3SSPublisher.h>
+#include <Model.h>
 #include <SafetyController.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
@@ -37,11 +38,10 @@ namespace M1M3 {
 namespace SS {
 
 ElevationForceComponent::ElevationForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Elevation", forceActuatorSettings->ElevationComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/ElevationForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/ElevationForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class ElevationForceComponent : public ForceComponent {
 public:
-    ElevationForceComponent(SafetyController* safetyController,
-                            ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    ElevationForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                             ForceActuatorSettings* forceActuatorSettings);
 
     void applyElevationForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/FinalForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/FinalForceComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <FinalForceComponent.h>
 #include <M1M3SSPublisher.h>
+#include <Model.h>
 #include <SafetyController.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
@@ -36,11 +37,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-FinalForceComponent::FinalForceComponent(SafetyController* safetyController,
-                                         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+FinalForceComponent::FinalForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                                          ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Final", forceActuatorSettings->FinalComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _enabledForceActuators = M1M3SSPublisher::get().getEnabledForceActuators();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;

--- a/src/LSST/M1M3/SS/ForceComponents/FinalForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/FinalForceComponent.h
@@ -46,12 +46,10 @@ public:
     /**
      * @brief Sets internal variables.
      *
-     * @param safetyController
      * @param forceActuatorApplicationSettings
      * @param forceActuatorSettings
      */
-    FinalForceComponent(SafetyController* safetyController,
-                        ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    FinalForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                         ForceActuatorSettings* forceActuatorSettings);
 
     /**

--- a/src/LSST/M1M3/SS/ForceComponents/OffsetForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/OffsetForceComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <OffsetForceComponent.h>
 #include <M1M3SSPublisher.h>
+#include <Model.h>
 #include <SafetyController.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
@@ -36,11 +37,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-OffsetForceComponent::OffsetForceComponent(SafetyController* safetyController,
-                                           ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+OffsetForceComponent::OffsetForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                                            ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Offset", forceActuatorSettings->OffsetComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/OffsetForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/OffsetForceComponent.h
@@ -39,8 +39,7 @@ namespace SS {
  */
 class OffsetForceComponent : public ForceComponent {
 public:
-    OffsetForceComponent(SafetyController* safetyController,
-                         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    OffsetForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                          ForceActuatorSettings* forceActuatorSettings);
 
     void applyOffsetForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/StaticForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/StaticForceComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <StaticForceComponent.h>
 #include <M1M3SSPublisher.h>
+#include <Model.h>
 #include <SafetyController.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
@@ -36,11 +37,10 @@ namespace LSST {
 namespace M1M3 {
 namespace SS {
 
-StaticForceComponent::StaticForceComponent(SafetyController* safetyController,
-                                           ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+StaticForceComponent::StaticForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                                            ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Static", forceActuatorSettings->StaticComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/StaticForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/StaticForceComponent.h
@@ -37,8 +37,7 @@ namespace SS {
 
 class StaticForceComponent : public ForceComponent {
 public:
-    StaticForceComponent(SafetyController* safetyController,
-                         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    StaticForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                          ForceActuatorSettings* forceActuatorSettings);
 
     void applyStaticForces(std::vector<float>* x, std::vector<float>* y, std::vector<float>* z);

--- a/src/LSST/M1M3/SS/ForceComponents/ThermalForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/ThermalForceComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <ThermalForceComponent.h>
 #include <M1M3SSPublisher.h>
+#include <Model.h>
 #include <SafetyController.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
@@ -37,11 +38,10 @@ namespace M1M3 {
 namespace SS {
 
 ThermalForceComponent::ThermalForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Thermal", forceActuatorSettings->ThermalComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/ThermalForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/ThermalForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class ThermalForceComponent : public ForceComponent {
 public:
-    ThermalForceComponent(SafetyController* safetyController,
-                          ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    ThermalForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                           ForceActuatorSettings* forceActuatorSettings);
 
     void applyThermalForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/ForceComponents/VelocityForceComponent.cpp
+++ b/src/LSST/M1M3/SS/ForceComponents/VelocityForceComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <VelocityForceComponent.h>
 #include <M1M3SSPublisher.h>
+#include <Model.h>
 #include <SafetyController.h>
 #include <ForceActuatorApplicationSettings.h>
 #include <ForceActuatorSettings.h>
@@ -37,11 +38,10 @@ namespace M1M3 {
 namespace SS {
 
 VelocityForceComponent::VelocityForceComponent(
-        SafetyController* safetyController,
         ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
         ForceActuatorSettings* forceActuatorSettings)
         : ForceComponent("Velocity", forceActuatorSettings->VelocityComponentSettings) {
-    _safetyController = safetyController;
+    _safetyController = Model::get().getSafetyController();
     _forceActuatorApplicationSettings = forceActuatorApplicationSettings;
     _forceActuatorSettings = forceActuatorSettings;
     _forceActuatorState = M1M3SSPublisher::get().getEventForceActuatorState();

--- a/src/LSST/M1M3/SS/ForceComponents/VelocityForceComponent.h
+++ b/src/LSST/M1M3/SS/ForceComponents/VelocityForceComponent.h
@@ -36,8 +36,7 @@ namespace SS {
 
 class VelocityForceComponent : public ForceComponent {
 public:
-    VelocityForceComponent(SafetyController* safetyController,
-                           ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
+    VelocityForceComponent(ForceActuatorApplicationSettings* forceActuatorApplicationSettings,
                            ForceActuatorSettings* forceActuatorSettings);
 
     void applyVelocityForces(float* x, float* y, float* z);

--- a/src/LSST/M1M3/SS/Include/FaultCodes.h
+++ b/src/LSST/M1M3/SS/Include/FaultCodes.h
@@ -143,6 +143,18 @@ struct FaultCodes {
          */
         HardpointActuatorAirPressureOutside = _MASK_HARDPOINT | 0x06,
 
+        /**
+         * Triggered when hardpoint actuator is being commanded to move below
+         * low limit switch.
+         */
+        HardpointActuatorLimitLowError = _MASK_HARDPOINT | 0x07,
+
+        /**
+         * Triggered when hardpoint actuator is being commanded to move above
+         * low limit switch.
+         */
+        HardpointActuatorLimitHighError = _MASK_HARDPOINT | 0x08,
+
         TMAAzimuthTimeout = _MASK_TMA | 0x01,
         TMAElevationTimeout = _MASK_TMA | 0x02,
         TMAInclinometerDeviation = _MASK_TMA | 0x04,

--- a/src/LSST/M1M3/SS/Model/Model.cpp
+++ b/src/LSST/M1M3/SS/Model/Model.cpp
@@ -166,8 +166,8 @@ void Model::loadSettings(std::string settingsToApply) {
 
     delete _forceController;
     SPDLOG_INFO("Model: Creating force controller");
-    _forceController = new ForceController(forceActuatorApplicationSettings, forceActuatorSettings,
-                                           pidSettings, _safetyController);
+    _forceController =
+            new ForceController(forceActuatorApplicationSettings, forceActuatorSettings, pidSettings);
 
     SPDLOG_INFO("Model: Updating digital input output");
     _digitalInputOutput.setSafetyController(_safetyController);

--- a/src/LSST/M1M3/SS/Settings/SafetyControllerSettings.h
+++ b/src/LSST/M1M3/SS/Settings/SafetyControllerSettings.h
@@ -50,6 +50,7 @@ public:
     DisplacementSafetySettings Displacement;
     InclinometerSafetySettings Inclinometer;
     InterlockControllerSafetySettings Interlock;
+
     ForceControllerSafetySettings ForceController;
     CellLightsSafetySettings CellLights;
     PowerControllerSafetySettings PowerController;


### PR DESCRIPTION
When hardpoint limits are hit and the algorithm tries to move past the limit, fault the mirror - it cannot succeed rasing/lowering/operating the mirror, as HP limits are hit.