### PR TITLE
Fix HP & FA tests executions

### DIFF
--- a/src/LSST/M1M3/SS/Commands/ExitEngineeringCommand.cpp
+++ b/src/LSST/M1M3/SS/Commands/ExitEngineeringCommand.cpp
@@ -25,12 +25,25 @@
 #include <ExitEngineeringCommand.h>
 #include <M1M3SSPublisher.h>
 
+#include <spdlog/spdlog.h>
+
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
 ExitEngineeringCommand::ExitEngineeringCommand(int32_t commandID, MTM1M3_command_exitEngineeringC*)
         : Command(commandID) {}
+
+bool ExitEngineeringCommand::validate() {
+    if (M1M3SSPublisher::get().getEventForceActuatorBumpTestStatus()->actuatorId >= 0) {
+        M1M3SSPublisher::get().logCommandRejectionWarning(
+                "ExitEngineering",
+                fmt::format("Cannot exit engineering mode as bump test for actuator {} is in progress.",
+                            M1M3SSPublisher::get().getEventForceActuatorBumpTestStatus()->actuatorId));
+        return false;
+    }
+    return Command::validate();
+}
 
 void ExitEngineeringCommand::execute() { Context::get().exitEngineering(this); }
 

--- a/src/LSST/M1M3/SS/Commands/ExitEngineeringCommand.h
+++ b/src/LSST/M1M3/SS/Commands/ExitEngineeringCommand.h
@@ -36,6 +36,7 @@ class ExitEngineeringCommand : public Command {
 public:
     ExitEngineeringCommand(int32_t commandID, MTM1M3_command_exitEngineeringC*);
 
+    bool validate() override;
     void execute() override;
     void ackInProgress() override;
     void ackComplete() override;

--- a/src/LSST/M1M3/SS/Commands/RaiseM1M3Command.cpp
+++ b/src/LSST/M1M3/SS/Commands/RaiseM1M3Command.cpp
@@ -25,12 +25,25 @@
 #include <RaiseM1M3Command.h>
 #include <M1M3SSPublisher.h>
 
+#include <spdlog/spdlog.h>
+
 namespace LSST {
 namespace M1M3 {
 namespace SS {
 
 RaiseM1M3Command::RaiseM1M3Command(int32_t commandID, MTM1M3_command_raiseM1M3C* data) : Command(commandID) {
     _data.bypassReferencePosition = data->bypassReferencePosition;
+}
+
+bool RaiseM1M3Command::validate() {
+    if (M1M3SSPublisher::get().getEventForceActuatorBumpTestStatus()->actuatorId >= 0) {
+        M1M3SSPublisher::get().logCommandRejectionWarning(
+                "RaiseM1M3",
+                fmt::format("Cannot raise M1M3 as bump test for actuator {} is in progress.",
+                            M1M3SSPublisher::get().getEventForceActuatorBumpTestStatus()->actuatorId));
+        return false;
+    }
+    return Command::validate();
 }
 
 void RaiseM1M3Command::execute() { Context::get().raiseM1M3(this); }

--- a/src/LSST/M1M3/SS/Commands/RaiseM1M3Command.h
+++ b/src/LSST/M1M3/SS/Commands/RaiseM1M3Command.h
@@ -38,6 +38,7 @@ public:
 
     MTM1M3_command_raiseM1M3C* getData() { return &_data; }
 
+    bool validate() override;
     void execute() override;
     void ackInProgress() override;
     void ackComplete() override;

--- a/src/LSST/M1M3/SS/Controllers/BumpTestController.h
+++ b/src/LSST/M1M3/SS/Controllers/BumpTestController.h
@@ -36,7 +36,7 @@ namespace SS {
  * mirror, and compare measured forces from force cell.
  *
  * Bump test is performed in the following stages (per actuator, so if both
- * primary and secondary shall be tested, repeat:
+ * primary and secondary shall be tested, repeat):
  *
  * 1. check that average of _testMeasurements measured forces roughly equal to 0 (in _tolerance)
  * 2. apply a small positive force
@@ -66,8 +66,10 @@ public:
      * @param actuatorId actuator ID (101-443)
      * @param testPrimary true if test primary (Z) actuator
      * @param testSecondary true if test secondary (X or Y) actuator
+     *
+     * @return 0 on success, 1 if another force actuator is being tested
      */
-    void setBumpTestActuator(int actuatorId, bool testPrimary, bool testSecondary);
+    int setBumpTestActuator(int actuatorId, bool testPrimary, bool testSecondary);
 
     /**
      * Run single loop. Shall be called from update command after telemetry
@@ -77,8 +79,10 @@ public:
 
     /**
      * Stops all running bump tests.
+     *
+     * @param forced if true, make sure Far Neighbor checks bypass is disabled
      */
-    void stopAll();
+    void stopAll(bool forced);
 
     /**
      * Stops bump test on given cylinder.

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
@@ -381,8 +381,10 @@ void SafetyController::forceControllerNotifyForceClipping(bool conditionFlag) {
 void SafetyController::positionControllerNotifyLimitLow(int hp, bool conditionFlag) {
     if (conditionFlag) {
         if (_hardpointLimitLowTriggered[hp] == false) {
-            _updateOverride(FaultCodes::HardpointActuatorLimitLowError, true, conditionFlag,
-                            "Hardpoint #{} hit low limit", hp + 1);
+            _updateOverride(FaultCodes::HardpointActuatorLimitLowError,
+                            M1M3SSPublisher::get().getEventDetailedState()->detailedState !=
+                                    MTM1M3::MTM1M3_shared_DetailedStates_ParkedEngineeringState,
+                            conditionFlag, "Hardpoint #{} hit low limit", hp + 1);
             _hardpointLimitLowTriggered[hp] = true;
         }
 
@@ -397,8 +399,10 @@ void SafetyController::positionControllerNotifyLimitLow(int hp, bool conditionFl
 void SafetyController::positionControllerNotifyLimitHigh(int hp, bool conditionFlag) {
     if (conditionFlag) {
         if (_hardpointLimitHighTriggered[hp] == false) {
-            _updateOverride(FaultCodes::HardpointActuatorLimitHighError, true, conditionFlag,
-                            "Hardpoint #{} hit high limit", hp + 1);
+            _updateOverride(FaultCodes::HardpointActuatorLimitHighError,
+                            M1M3SSPublisher::get().getEventDetailedState()->detailedState !=
+                                    MTM1M3::MTM1M3_shared_DetailedStates_ParkedEngineeringState,
+                            conditionFlag, "Hardpoint #{} hit high limit", hp + 1);
             _hardpointLimitHighTriggered[hp] = true;
         }
 

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
@@ -294,10 +294,10 @@ void SafetyController::forceControllerNotifyMagnitudeLimit(bool conditionFlag, f
                     "Force controller Magnitude Limit crossed {}", globalForce);
 }
 
-void SafetyController::forceControllerNotifyFarNeighborCheck(bool conditionFlag) {
+void SafetyController::forceControllerNotifyFarNeighborCheck(bool conditionFlag, std::string failed) {
     _updateOverride(FaultCodes::ForceControllerFarNeighborCheck,
                     _safetyControllerSettings->ForceController.FaultOnFarNeighborCheck, conditionFlag,
-                    "Force controller Far Neighbor Check failed");
+                    "Force controller Far Neighbor Check failed:{}", failed);
 }
 
 void SafetyController::forceControllerNotifyElevationForceClipping(bool conditionFlag) {

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.h
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.h
@@ -93,7 +93,7 @@ public:
     void forceControllerNotifyNearNeighborCheck(bool conditionFlag, std::string failed, float nominalZ,
                                                 float nominalZWarning);
     void forceControllerNotifyMagnitudeLimit(bool conditionFlag, float globalForce);
-    void forceControllerNotifyFarNeighborCheck(bool conditionFlag);
+    void forceControllerNotifyFarNeighborCheck(bool conditionFlag, std::string failed);
     void forceControllerNotifyElevationForceClipping(bool conditionFlag);
     void forceControllerNotifyAzimuthForceClipping(bool conditionFlag);
     void forceControllerNotifyThermalForceClipping(bool conditionFlag);

--- a/src/LSST/M1M3/SS/Include/ForceControllerSafetySettings.h
+++ b/src/LSST/M1M3/SS/Include/ForceControllerSafetySettings.h
@@ -24,9 +24,14 @@
 #ifndef FORCECONTROLLERSAFETYSETTINGS_H_
 #define FORCECONTROLLERSAFETYSETTINGS_H_
 
+#include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
 
-struct ForceControllerSafetySettings {
+/**
+ * Force Controller Safety settings - which force checks should be run.
+ */
+class ForceControllerSafetySettings {
+public:
     bool FaultOnSafetyLimit;
     bool FaultOnXMomentLimit;
     bool FaultOnYMomentLimit;
@@ -55,7 +60,8 @@ struct ForceControllerSafetySettings {
         FaultOnZMomentLimit = node["FaultOnZMomentLimit"].as<bool>();
         FaultOnNearNeighborCheck = node["FaultOnNearNeighborCheck"].as<bool>();
         FaultOnMagnitudeLimit = node["FaultOnMagnitudeLimit"].as<bool>();
-        FaultOnFarNeighborCheck = node["FaultOnFarNeighborCheck"].as<bool>();
+        configured_FaultOnFarNeighborCheck = FaultOnFarNeighborCheck =
+                node["FaultOnFarNeighborCheck"].as<bool>();
         FaultOnElevationForceClipping = node["FaultOnElevationForceClipping"].as<bool>();
         FaultOnAzimuthForceClipping = node["FaultOnAzimuthForceClipping"].as<bool>();
         FaultOnThermalForceClipping = node["FaultOnThermalForceClipping"].as<bool>();
@@ -70,6 +76,25 @@ struct ForceControllerSafetySettings {
         FaultOnVelocityForceClipping = node["FaultOnVelocityForceClipping"].as<bool>();
         FaultOnForceClipping = node["FaultOnForceClipping"].as<bool>();
     }
+
+    /**
+     * Sets safety settings for FA bump testing.
+     */
+    void enterBumpTesting() {
+        SPDLOG_TRACE("ForceControllerSafetySettings: enterBumpTesting()");
+        FaultOnFarNeighborCheck = false;
+    }
+
+    /**
+     * Retores settings for nominal, non-FA bump testing operation.
+     */
+    void exitBumpTesting() {
+        SPDLOG_TRACE("ForceControllerSafetySettings: exitBumpTesting()");
+        FaultOnFarNeighborCheck = configured_FaultOnFarNeighborCheck;
+    }
+
+private:
+    bool configured_FaultOnFarNeighborCheck;
 };
 
 #endif /* FORCECONTROLLERSAFETYSETTINGS_H_ */

--- a/src/LSST/M1M3/SS/States/ParkedEngineeringState.cpp
+++ b/src/LSST/M1M3/SS/States/ParkedEngineeringState.cpp
@@ -60,7 +60,7 @@ States::Type ParkedEngineeringState::update(UpdateCommand* command) {
 States::Type ParkedEngineeringState::raiseM1M3(RaiseM1M3Command* command) {
     SPDLOG_INFO("ParkedEngineeringState: raiseM1M3()");
 
-    Model::get().getBumpTestController()->stopAll();
+    Model::get().getBumpTestController()->stopAll(true);
 
     Model::get().getMirrorRaiseController()->start(command->getData()->bypassReferencePosition);
     return Model::get().getSafetyController()->checkSafety(States::RaisingEngineeringState);
@@ -69,7 +69,7 @@ States::Type ParkedEngineeringState::raiseM1M3(RaiseM1M3Command* command) {
 States::Type ParkedEngineeringState::exitEngineering(ExitEngineeringCommand* command) {
     SPDLOG_INFO("ParkedEngineeringState: exitEngineering()");
 
-    Model::get().getBumpTestController()->stopAll();
+    Model::get().getBumpTestController()->stopAll(true);
 
     Model::get().getDigitalInputOutput()->turnAirOn();
     Model::get().getPositionController()->stopMotion();
@@ -84,7 +84,7 @@ States::Type ParkedEngineeringState::exitEngineering(ExitEngineeringCommand* com
 States::Type ParkedEngineeringState::disable(DisableCommand* command) {
     SPDLOG_INFO("ParkedEngineeringState: disable()");
 
-    Model::get().getBumpTestController()->stopAll();
+    Model::get().getBumpTestController()->stopAll(true);
 
     // Stop any existing motion (chase and move commands)
     Model::get().getPositionController()->stopMotion();
@@ -112,7 +112,7 @@ States::Type ParkedEngineeringState::forceActuatorBumpTest(ForceActuatorBumpTest
 
 States::Type ParkedEngineeringState::killForceActuatorBumpTest(KillForceActuatorBumpTestCommand* command) {
     SPDLOG_INFO("ParkedEngineeringState: killForceActuatorBumpTest()");
-    Model::get().getBumpTestController()->stopAll();
+    Model::get().getBumpTestController()->stopAll(false);
     return Model::get().getSafetyController()->checkSafety(States::NoStateTransition);
 }
 

--- a/src/LSST/M1M3/SS/States/StandbyState.cpp
+++ b/src/LSST/M1M3/SS/States/StandbyState.cpp
@@ -28,7 +28,6 @@
 #include <SafetyController.h>
 #include <PowerController.h>
 #include <SettingReader.h>
-#include <StartCommand.h>
 #include <Gyro.h>
 
 #include <thread>
@@ -49,6 +48,8 @@ States::Type StandbyState::update(UpdateCommand* command) {
 
 States::Type StandbyState::start(StartCommand* command) {
     SPDLOG_INFO("StandbyState: start()");
+    SettingReader::instance().getSafetyControllerSettings()->ForceController.exitBumpTesting();
+
     Model::get().loadSettings(command->getData()->configurationOverride);
     M1M3SSPublisher::get().getEventConfigurationApplied()->version =
             SettingReader::instance().getSettingsVersion();

--- a/src/LSST/M1M3/SS/States/StandbyState.h
+++ b/src/LSST/M1M3/SS/States/StandbyState.h
@@ -24,6 +24,8 @@
 #ifndef STANDBYSTATE_H_
 #define STANDBYSTATE_H_
 
+#include <UpdateCommand.h>
+#include <StartCommand.h>
 #include <State.h>
 
 namespace LSST {

--- a/src/LSST/M1M3/SS/Threads/SubscriberThread.cpp
+++ b/src/LSST/M1M3/SS/Threads/SubscriberThread.cpp
@@ -23,6 +23,7 @@
 
 #include <ControllerThread.h>
 #include <SubscriberThread.h>
+#include <M1M3SSPublisher.h>
 #include <M1M3SSSubscriber.h>
 #include <chrono>
 #include <thread>
@@ -103,7 +104,9 @@ void SubscriberThread::_enqueueCommandIfAvailable(Command* command) {
             if (command->validate()) {
                 ControllerThread::get().enqueue(command);
             } else {
-                command->ackFailed("Validation");
+                auto info = M1M3SSPublisher::get().getEventCommandRejectionWarning();
+                command->ackFailed(
+                        fmt::format("Command \"{}\" validation failed: {} ", info->command, info->reason));
                 delete command;
             }
         } catch (std::exception& ex) {


### PR DESCRIPTION
- Don't check HP limits when in parked engineering mode
- report FA causing far neighbor failure
- skip FarNeighbor checks while bump testing FA
