### PR TITLE
Changed HP following error count settings to 10

### DIFF
--- a/SettingFiles/Sets/Default/1/SafetyControllerSettings.yaml
+++ b/SettingFiles/Sets/Default/1/SafetyControllerSettings.yaml
@@ -57,7 +57,7 @@ ForceControllerSettings:
   FaultOnForceClipping: On
 PositionControllerSettings:
   FollowingErrorPercentage: 50
-  FaultNumberOfFollowingErrors: 5
+  FaultNumberOfFollowingErrors: 10
   FaultOnUnstableCount: 100
 CellLightSettings:
   FaultOnOutputMismatch: On

--- a/src/LSST/M1M3/SS/Controllers/PositionController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/PositionController.cpp
@@ -470,6 +470,7 @@ void PositionController::_checkFollowingError(int hp) {
     if (abs(_hardpointActuatorData->stepsCommanded[hp]) >
         _positionControllerSettings->encoderToStepsCoefficient) {
         double travelled = _hardpointActuatorData->encoder[hp] - _lastEncoderCount[hp];
+        // due to condition above divider is > 1 or < -1, division by 0 cannot occur
         double shouldTravell = _hardpointActuatorData->stepsCommanded[hp] /
                                _positionControllerSettings->encoderToStepsCoefficient;
 

--- a/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/SafetyController.cpp
@@ -570,7 +570,7 @@ void SafetyController::hardpointActuatorFollowingError(int hp, double fePercent)
     double feObserved = fabs(100 - fePercent);
     _updateOverride(FaultCodes::HardpointActuatorFollowingError,
                     (feCounts >= 0) && (_hardpointFeViolations[hp] > feCounts), feObserved > feRange,
-                    "Hardpoint {} following error out of range: {:.2f}", hp, fePercent);
+                    "Hardpoint {} following error out of range: {:.2f}", hp + 1, feObserved);
     if (feObserved > feRange) {
         _hardpointFeViolations[hp]++;
     } else {


### PR DESCRIPTION
Tests with surrogate reveal that original value of 5 isn't enough.
Changed value to 10 fixed the problem. 10 is probably needed, as small
final movements (when failure was observed) might take longer time to
execute than envisioned.
