### PR TITLE
DM-39872: useGyroscope flag, calculate angular velocities from TMA velocities

### DIFF
--- a/SettingFiles/v1/_init.yaml
+++ b/SettingFiles/v1/_init.yaml
@@ -146,6 +146,7 @@ ForceActuatorSettings:
   ForceActuatorNearZNeighborsTablePath: ForceActuatorNearNeighborZTable.csv
   ForceActuatorNeighborsTablePath: ForceActuatorNeighborsTable.csv
   UseInclinometer: True
+  UseGyroscope: False
   MirrorXMoment: -65311
   MirrorYMoment: -20000
   MirrorZMoment: -20000

--- a/SettingFiles/v1/_init.yaml
+++ b/SettingFiles/v1/_init.yaml
@@ -146,7 +146,7 @@ ForceActuatorSettings:
   ForceActuatorNearZNeighborsTablePath: ForceActuatorNearNeighborZTable.csv
   ForceActuatorNeighborsTablePath: ForceActuatorNeighborsTable.csv
   UseInclinometer: True
-  UseGyroscope: False
+  UseGyroscope: True
   MirrorXMoment: -65311
   MirrorYMoment: -20000
   MirrorZMoment: -20000

--- a/src/LSST/M1M3/SS/Controllers/ForceController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/ForceController.cpp
@@ -236,8 +236,9 @@ void ForceController::updateAppliedForces() {
     }
     if (_velocityForceComponent.isActive()) {
         if (_velocityForceComponent.isEnabled()) {
-            _velocityForceComponent.applyVelocityForcesByAngularVelocity(
-                    _gyroData->angularVelocityX, _gyroData->angularVelocityY, _gyroData->angularVelocityZ);
+            double x, y, z;
+            TMA::instance().getMirrorAngularVelocities(x, y, z);
+            _velocityForceComponent.applyVelocityForcesByAngularVelocity(x, y, z);
         }
         _velocityForceComponent.update();
     }

--- a/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
+++ b/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
@@ -40,6 +40,7 @@
 #include <SettingReader.h>
 #include <SimulatedFPGA.h>
 #include <Timestamp.h>
+#include <Units.h>
 
 using namespace LSST::M1M3::SS;
 using namespace LSST::M1M3::SS::FPGAAddresses;
@@ -49,7 +50,7 @@ using namespace std::chrono_literals;
 const float MOUNT_SIMULATION_STEP = 1 / 50.0;
 // Gyroscope simulated velocity change. Same time unit as MOUNT_SIMULATION_STEP. Reach roughly max +-6
 // deg/sec.
-const float GYRO_SIMULATE_STEP = 1 / 375.0;
+const float GYRO_SIMULATE_STEP = D2RAD / 375.0;
 // Mount data are valid for 20 seconds in simulation, before simulated mount movement takes over
 #define MOUNT_VALIDITY 20s
 
@@ -158,9 +159,9 @@ void SimulatedFPGA::pullTelemetry() {
                         _mountSimulatedMovementFirstPass = false;
                         if (ForceActuatorSettings::instance().useGyroscope == true) {
                             double gyroRatio = (_mountElevation - 45.0) / 90.0;
-                            supportFPGAData.GyroRawX = -12 * gyroRatio;
-                            supportFPGAData.GyroRawY = -12 * gyroRatio;
-                            supportFPGAData.GyroRawZ = 12 * gyroRatio;
+                            supportFPGAData.GyroRawX = -12 * gyroRatio * D2RAD;
+                            supportFPGAData.GyroRawY = -12 * gyroRatio * D2RAD;
+                            supportFPGAData.GyroRawZ = 12 * gyroRatio * D2RAD;
                         }
                     }
                     if (_simulatingToHorizon) {

--- a/src/LSST/M1M3/SS/Settings/ForceActuatorSettings.cpp
+++ b/src/LSST/M1M3/SS/Settings/ForceActuatorSettings.cpp
@@ -162,6 +162,7 @@ void ForceActuatorSettings::load(YAML::Node doc) {
         _loadNeighborsTable(doc["ForceActuatorNeighborsTablePath"].as<std::string>());
 
         useInclinometer = doc["UseInclinometer"].as<bool>();
+        useGyroscope = doc["UseGyroscope"].as<bool>();
         mirrorXMoment = doc["MirrorXMoment"].as<float>();
         mirrorYMoment = doc["MirrorYMoment"].as<float>();
         mirrorZMoment = doc["MirrorZMoment"].as<float>();

--- a/src/LSST/M1M3/SS/Subscriber/TMA.h
+++ b/src/LSST/M1M3/SS/Subscriber/TMA.h
@@ -67,30 +67,44 @@ public:
     /**
      * Returns mirror elevation. Uses either telescope provided data, or internal inclinometer readout.
      *
+     * @param forceTelescope if true, telescope elevation angle is provided
+     *
      * @return telescope elevation in degrees. 0 for horizon, 90 for zenith.
      */
-    double getElevation();
+    double getElevation(bool forceTelescope = false);
+
+    /**
+     * Returns mirror angular X, Y and Z velocities. Those are calculated from
+     * azimuth and elevation velocities.
+     */
+    void getMirrorAngularVelocities(double& x, double& y, double& z);
 
     /**
      * Returns elevation sin.
      *
+     * @param forceTelescope if true, telescope elevation angle is provided
+     *
      * @return elvation sin
      */
-    double getElevationSin() { return sin(getElevation() * D2RAD); }
+    double getElevationSin(bool forceTelescope = false) { return sin(getElevation(forceTelescope) * D2RAD); }
 
     /**
      * Returns elevation cos.
      *
+     * @param forceTelescope if true, telescope elevation angle is provided
+     *
      * @return elevation cos
      */
-    double getElevationCos() { return cos(getElevation() * D2RAD); }
+    double getElevationCos(bool forceTelescope = false) { return cos(getElevation(forceTelescope) * D2RAD); }
 
 private:
     double _azimuth_Timestamp;
     double _azimuth_Actual;
+    double _azimuth_ActualVelocity;
 
     double _elevation_Timestamp;
     double _elevation_Actual;
+    double _elevation_ActualVelocity;
 };
 
 }  // namespace SS


### PR DESCRIPTION
- UseGyroscope settings
- Simulate change of gyroscope values
- Proper units - rad/sec are used for calculations.
- Don't test for following error if in disabled state
- Command for enable/disable forceComponent
- Distribute disabled FA forces to quadrants
