### PR TITLE
useAccelerometers flags - can take acceleration from TMA

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node {
     def SALUSER_HOME = "/home/saluser"
     def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
     // branches requiring changes in XML from default develop branch
-    def XML_BRANCH = BRANCH in ["main", "tickets/DM-39824"] ? BRANCH : "develop"
+    def XML_BRANCH = BRANCH in ["main", "tickets/DM-39891"] ? BRANCH : "develop"
     def CRIO_BRANCH = BRANCH in ["main", "tickets/DM-38668"] ? BRANCH : "develop"
     stage('Cloning sources')
     {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node {
     def SALUSER_HOME = "/home/saluser"
     def BRANCH = (env.CHANGE_BRANCH != null) ? env.CHANGE_BRANCH : env.BRANCH_NAME
     // branches requiring changes in XML from default develop branch
-    def XML_BRANCH = BRANCH in ["main", "tickets/DM-39891"] ? BRANCH : "develop"
+    def XML_BRANCH = BRANCH in ["main", "tickets/DM-38668"] ? BRANCH : "develop"
     def CRIO_BRANCH = BRANCH in ["main", "tickets/DM-38668"] ? BRANCH : "develop"
     stage('Cloning sources')
     {

--- a/SettingFiles/v1/_init.yaml
+++ b/SettingFiles/v1/_init.yaml
@@ -147,6 +147,7 @@ ForceActuatorSettings:
   ForceActuatorNeighborsTablePath: ForceActuatorNeighborsTable.csv
   UseInclinometer: True
   UseGyroscope: True
+  UseAccelerometers: True
   MirrorXMoment: -65311
   MirrorYMoment: -20000
   MirrorZMoment: -20000

--- a/default_ts-M1M3support
+++ b/default_ts-M1M3support
@@ -1,3 +1,4 @@
+M1M3_SUPPORT_CONFIG="/var/lib/M1M3support"
 OSPL_HOME=/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux
 OSPL_RELEASE=6.10.4
 OSPL_LOGPATH=/var/log/m1m3

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -1,0 +1,18 @@
+.. _Version_History:
+
+===============
+Version History
+===============
+
+v2.12.0
+-------
+
+* Configuration is stored in standard LSST configuration format
+* Sends proper messages during CSC initialization
+
+v2.11.0
+-------
+
+* Don't turn on lights on startup
+* Booster valve automatic activation (based on accelerometers/following error)
+* Measured forces limits

--- a/init
+++ b/init
@@ -42,8 +42,12 @@ startdaemon(){
 		fi
 	done
 	logger -t M1M3support_start -p user.info "Starting with IP $LSST_DDS_IP"
-	echo -n "Starting TS M1M3 support:"
-	start-stop-daemon --start --oknodo --pidfile ${PIDFILE} --startas $DAEMON -- -p ${PIDFILE} -u m1m3:m1m3
+	OPTS="-u m1m3:m1m3 "
+	if [ $M1M3_SUPPORT_CONFIG ]; then
+		OPTS+="-c $M1M3_SUPPORT_CONFIG "
+	fi
+	echo -n "Starting TS M1M3 support: (config"
+	start-stop-daemon --start --oknodo --pidfile ${PIDFILE} --startas $DAEMON -- -p ${PIDFILE} ${OPTS}
 	echo "done"
 }
 stopdaemon(){

--- a/src/LSST/M1M3/SS/Accelerometer/calibrate
+++ b/src/LSST/M1M3/SS/Accelerometer/calibrate
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from astropy.time import Time, TimeDelta
+import astropy.units as u
+import enum
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from lsst_efd_client import EfdClient, resample
+
+# distances (m) between an accelerometer and the center of telescope rotation
+# (intersection of azimuth and elevation axis)
+A1_CR = 4 * u.m
+A2_CR = 4 * u.m
+A3_CR = 4 * u.m
+A5_CR = 4 * u.m
+
+RAW_FIELDS = [f"rawAccelerometer{a}" for a in range(8)]
+
+class PeridoType(enum.IntEnum):
+    HORIZON = 0
+    ZENITH = 1
+
+
+class CalibrateACAccelerometer:
+    def __init__(self, start: Time, end: Time):
+        self.client = EfdClient("summit_efd")
+        self.start = start
+        self.end = end
+        self.interval = end - start
+
+        self._current_time = start
+        self._current_index = 0
+        self._period = 1800
+        self._tma_data = None
+
+    async def _load_period(self):
+            period_end = min(self.end, self._current_time + TimeDelta(self._period, format="sec"))
+            logging.info("Probing interval {self._current_time} - {period_end}")
+
+            self.elevation = await self.client.select_time_series(
+                "lsst.sal.MTMount.elevation",
+                ["timestamp", "actualPosition", "actualVelocity", "demandVelocity"],
+                self._current_time,
+                period_end,
+            )
+            self.elevation = self.elevation.rename(lambda n: "elevation_" + n, axis="columns")
+
+            self.azimuth = await self.client.select_time_series(
+                "lsst.sal.MTMount.elevation",
+                ["timestamp", "actualPosition", "actualVelocity", "demandVelocity"],
+                self._current_time,
+                period_end,
+            )
+            self.azimuth = self.azimuth.rename(lambda n: "azimuth_" + n, axis="columns")
+
+            self._tma_data = resample(self.elevation, self.azimuth)
+            self._current_index = 0
+
+            # derivative
+            index = self._tma_data.index
+            den = index.to_series().diff().dt.total_seconds()
+            num = self._tma_data.diff()
+            self._tma_derivative = num.div(den, axis=0)
+
+            index = self.elevation.index
+            den = index.to_series().diff().dt.total_seconds()
+            num = self.elevation.diff()
+            self.elevation_acc = num.div(den, axis=0)
+
+
+    async def next_period(self) -> PeridoType:
+        while self._current_time < self.end:
+            if self._tma_data is None or self._current_index > len(self._tma_data):
+                await self._load_period()
+                print("Derivative")
+                print(self._tma_derivative)
+                (self._tma_derivative["elevation_demandVelocity"] / self._tma_derivative["elevation_timestamp"]).plot(style="x-")
+                (self._tma_derivative["elevation_actualVelocity"] / self._tma_derivative["elevation_timestamp"]).plot(style=".-")
+                (self.elevation_acc["elevation_actualVelocity"] / self.elevation_acc["elevation_timestamp"]).plot(style="o-")
+
+                (self.elevation_acc["elevation_demandVelocity"] / self.elevation_acc["elevation_timestamp"]).plot(style="|-")
+
+                plt.legend(["el. demand", "el. actual", "el only actual", "el only demand"])
+                plt.show()
+
+            break
+
+            self._current_time = self.end
+
+    async def stat(self, start: Time, end: Time) -> list[tuple[float, float]]:
+        elevation = await self.client.select_time_series(
+            "lsst.sal.MTMount.elevation", ["actualPosition", "demandPosition"], start, end
+        )
+
+        try:
+            actual = elevation["actualPosition"]
+            demand = elevation["demandPosition"]
+
+            print(f"Elevation {np.mean(actual):.6f} {np.min(actual):.6f} {np.max(actual):.6f}")
+        except KeyError:
+            print("Unknow elevation, perharps TMA isn't running?")
+
+        dc_accelerometers = await self.client.select_time_series(
+            "lsst.sal.MTM1M3.accelerometerData", "*", start, end
+        )
+
+        stat = [(np.mean(dc_accelerometers[field]), np.std(dc_accelerometers[field])) for field in RAW_FIELDS]
+
+        for a in range(8):
+            print(f"Average {a+1}: {stat[a][0] * 1000:.1f} stdev {stat[a][1]}")
+        return stat
+
+    async def run(self, compare_times: list[Time]) -> None:
+        reference = await self.stat(self.start, self.end)
+
+        for t in compare_times:
+            stat = await self.stat(t, t + self.interval)
+            for a in range(8):
+                print(f"{a+1} std diff: {(stat[a][1] - reference[a][1]) * 1000} ratio: {(stat[a][1] / reference[a][1]) * 1000}")
+
+async def main(start: Time, end: Time, compare_times: list[Time]) -> None:
+    calibrator = CalibrateACAccelerometer(args.start, args.end)
+    # await calibrator.run(compare_times)
+    await calibrator.next_period()
+
+
+def parse_interval(interval: str)->float:
+    if len(interval) == 0:
+        raise RuntimeError("Empty interval specified")
+    suffix = interval[-1]
+    if suffix >= "0" and suffix <= "9":
+        return float(suffix)
+    elif suffix == "s":
+        return float(interval[:-1])
+    elif suffix == "m":
+        return float(interval[:-1]) * 60
+    elif suffix == "h":
+        return float(interval[:-1]) * 3600
+    elif suffix == "D":
+        return float(interval[:-1]) * 86400
+
+
+parser = argparse.ArgumentParser(
+    prog="DC average", description="Calculate DC accelerometer average"
+)
+
+parser.add_argument(
+    "--start",
+    help="start time",
+    type=Time,
+    default=Time.now() - TimeDelta(5, format="sec"),
+)
+parser.add_argument("--end", help="end time", type=Time)
+
+parser.add_argument(
+    "--compare",
+    help="Start times to compare with",
+    type=Time,
+    action="append",
+    default=[],
+)
+
+parser.add_argument("--interval", help="time interval to search", type=parse_interval)
+
+args = parser.parse_args()
+
+if args.end is not None and args.interval is not None:
+    sys.exit("Cannot specify both end time and interval")
+
+if args.end is None:
+    if args.interval is not None:
+        args.end = args.start + TimeDelta(args.interval, format="sec")
+    else:
+        args.end = args.start + TimeDelta(180, format="sec")
+
+print(f"Averages from {args.start} to {args.end}")
+
+asyncio.run(main(args.start, args.end, args.compare))

--- a/src/LSST/M1M3/SS/Controllers/ForceController.cpp
+++ b/src/LSST/M1M3/SS/Controllers/ForceController.cpp
@@ -196,9 +196,9 @@ void ForceController::updateAppliedForces() {
 
     if (_accelerationForceComponent.isActive()) {
         if (_accelerationForceComponent.isEnabled()) {
-            _accelerationForceComponent.applyAccelerationForcesByAngularAccelerations(
-                    _accelerometerData->angularAccelerationX, _accelerometerData->angularAccelerationY,
-                    _accelerometerData->angularAccelerationZ);
+            double x, y, z;
+            TMA::instance().getMirrorAngularAccelerations(x, y, z);
+            _accelerationForceComponent.applyAccelerationForcesByAngularAccelerations(x, y, z);
         }
         _accelerationForceComponent.update();
     }

--- a/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
+++ b/src/LSST/M1M3/SS/FPGA/SimulatedFPGA.cpp
@@ -51,6 +51,10 @@ const float MOUNT_SIMULATION_STEP = 1 / 50.0;
 // Gyroscope simulated velocity change. Same time unit as MOUNT_SIMULATION_STEP. Reach roughly max +-6
 // deg/sec.
 const float GYRO_SIMULATE_STEP = D2RAD / 375.0;
+// Accelerometers simulated acceleration change. Same time unit as MOUNT_SIMULATION_STEP. Reach roughly +-6
+// deg/sec.
+const float ACCEL_SIMULATED_STEP = D2RAD / 374.0;
+
 // Mount data are valid for 20 seconds in simulation, before simulated mount movement takes over
 #define MOUNT_VALIDITY 20s
 

--- a/src/LSST/M1M3/SS/Settings/ForceActuatorSettings.cpp
+++ b/src/LSST/M1M3/SS/Settings/ForceActuatorSettings.cpp
@@ -163,6 +163,7 @@ void ForceActuatorSettings::load(YAML::Node doc) {
 
         useInclinometer = doc["UseInclinometer"].as<bool>();
         useGyroscope = doc["UseGyroscope"].as<bool>();
+        useAccelerometers = doc["UseAccelerometers"].as<bool>();
         mirrorXMoment = doc["MirrorXMoment"].as<float>();
         mirrorYMoment = doc["MirrorYMoment"].as<float>();
         mirrorZMoment = doc["MirrorZMoment"].as<float>();

--- a/src/LSST/M1M3/SS/Subscriber/TMA.h
+++ b/src/LSST/M1M3/SS/Subscriber/TMA.h
@@ -55,14 +55,14 @@ public:
      *
      * @param data MTMount_azimuth data
      */
-    void updateTMAAzimuth(MTMount_azimuthC* data);
+    void updateTMAAzimuth(MTMount_azimuthC *data);
 
     /**
      * Updates elevation data to match current TMA data. Should be called on reception of new elevation data.
      *
      * @param data MTMount_elevation data
      */
-    void updateTMAElevation(MTMount_elevationC* data);
+    void updateTMAElevation(MTMount_elevationC *data);
 
     /**
      * Returns mirror elevation. Uses either telescope provided data, or internal inclinometer readout.
@@ -77,7 +77,9 @@ public:
      * Returns mirror angular X, Y and Z velocities. Those are calculated from
      * azimuth and elevation velocities.
      */
-    void getMirrorAngularVelocities(double& x, double& y, double& z);
+    void getMirrorAngularVelocities(double &x, double &y, double &z);
+
+    void getMirrorAngularAccelerations(double &ax, double &ay, double &az);
 
     /**
      * Returns elevation sin.
@@ -98,13 +100,15 @@ public:
     double getElevationCos(bool forceTelescope = false) { return cos(getElevation(forceTelescope) * D2RAD); }
 
 private:
-    double _azimuth_Timestamp;
-    double _azimuth_Actual;
-    double _azimuth_ActualVelocity;
+    /// hold values needed for acceleration calculation
+    MTMount_azimuthC _last_azimuth_data;
+    MTMount_elevationC _last_elevation_data;
 
-    double _elevation_Timestamp;
-    double _elevation_Actual;
-    double _elevation_ActualVelocity;
+    double _azimuth_demand_acceleration;
+    double _azimuth_actual_acceleration;
+
+    double _elevation_demand_acceleration;
+    double _elevation_actual_acceleration;
 };
 
 }  // namespace SS


### PR DESCRIPTION
- UseGyroscope settings
- Simulate change of gyroscope values
- Proper units - rad/sec are used for calculations.
- version history file
- Script to calibrate DC Accelerometers
- Calculate mirror acceleration from TMA velocities
- M1M3_SUPPORT_CONFIG argument
